### PR TITLE
changed method getComponentDataChannelsIds

### DIFF
--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java
@@ -434,24 +434,33 @@ public class RestServer {
         return response;
     }
 
-    @Path("/runtime/model/components/{componentId}/channels/data/ids")
+    @Path("/runtime/model/components/{componentId}/{portId}/channels/data/ids")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getComponentDataChannelsIds(@PathParam("componentId") String componentId) {
+    public String getComponentDataChannelsIds(@PathParam("componentId") String componentId,
+            @PathParam("portId") String portId) {
         String response = "";
         String errorMessage = "";
 
         try {
             componentId = astericsAPIEncoding.decodeString(componentId);
+            portId = astericsAPIEncoding.decodeString(portId);
 
             final IRuntimeModel currentRuntimeModel = DeploymentManager.instance.getCurrentRuntimeModel();
-            List<String> dataChannelIds = new ArrayList<String>();
+            Map<String, List<String>> dataChannelIds = new HashMap<>();
 
             Set<IChannel> dataChannels = currentRuntimeModel.getChannels();
             for (IChannel dataChannel : dataChannels) {
-                if ((dataChannel.getSource().getComponentInstanceID().equals(componentId))
-                        || (dataChannel.getTarget().getComponentInstanceID().equals(componentId))) {
-                    dataChannelIds.add(dataChannel.getChannelID());
+                String targetComponent = dataChannel.getTarget().getComponentInstanceID();
+                String sourceComponent = dataChannel.getSource().getComponentInstanceID();
+                String targetPort = dataChannel.getTarget().getPortID();
+                String sourcePort = dataChannel.getSource().getPortID();
+                if (targetComponent.equals(componentId) && targetPort.equals(portId)) {
+                    List<String> sourceComponentAndPort = Arrays.asList(sourceComponent, sourcePort);
+                    dataChannelIds.put(dataChannel.getChannelID(), sourceComponentAndPort);
+                } else if (sourceComponent.equals(componentId) && sourcePort.equals(portId)) {
+                    List<String> targetComponentAndPort = Arrays.asList(targetComponent, targetPort);
+                    dataChannelIds.put(dataChannel.getChannelID(), targetComponentAndPort);
                 }
             }
 


### PR DESCRIPTION
made pull request in order to have remaining diff-view of this method for my thesis (Asterics Ergo). Also should be concerned to be merged at some time because the existing implementation of the method is not useful in my opinion.

changed method getComponentDataChannelsIds to get only the ids of channels connected to a specific port of the component. Returns an JSON-Object containing the channelIDs as keys and as values a list with 2 elements: [componentId, portId] this channel is connected to.