### PR TITLE
Make resourceregistry nonstatic

### DIFF
--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/AsapiSupport.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/AsapiSupport.java
@@ -135,7 +135,7 @@ public class AsapiSupport {
                     logger.fine("getComponentDescriptorsAsXml()");
                     String response = "";
                     try {
-                        response = ResourceRegistry.getResourceContentAsString(BundleManager.COMPONENT_COLLECTION_CACHE_FILE_URI.toURL().openStream());
+                        response = ResourceRegistry.getInstance().getResourceContentAsString(BundleManager.COMPONENT_COLLECTION_CACHE_FILE_URI.toURL().openStream());
                     } catch (IOException e) {
                         logger.severe("Error reading cached component collection from file <" + BundleManager.COMPONENT_COLLECTION_CACHE_FILE_URI
                                 + ">, reason: " + e.getMessage());
@@ -1092,7 +1092,7 @@ public class AsapiSupport {
     public boolean deleteModelFile(String filename) throws AREAsapiException {
         File f;
         try {
-            f = ResourceRegistry.toFile(ResourceRegistry.getInstance().getResource(filename, RES_TYPE.MODEL));
+            f = ResourceRegistry.getInstance().toFile(ResourceRegistry.getInstance().getResource(filename, RES_TYPE.MODEL));
 
             // Make sure the file or directory exists and isn't write protected
             if (!f.exists()) {
@@ -1129,7 +1129,7 @@ public class AsapiSupport {
      */
     public String[] listAllStoredModels() throws AREAsapiException {
         List<URI> storedModelList = ResourceRegistry.getInstance().getModelList(true);
-        return ResourceRegistry.toStringArray(storedModelList);
+        return ResourceRegistry.getInstance().toStringArray(storedModelList);
     }
 
     /**
@@ -1180,7 +1180,7 @@ public class AsapiSupport {
         String webappPath = ResourceRegistry.WEBAPP_FOLDER + webappId;
         try {
             URI webappUri = ResourceRegistry.getInstance().getResource(webappPath, RES_TYPE.WEB_DOCUMENT_ROOT);
-            if(!ResourceRegistry.resourceExists(webappUri)) {
+            if(!ResourceRegistry.getInstance().resourceExists(webappUri)) {
                 String msg = MessageFormat.format("tried to store data for webapp with ID <{0}>, but it does not exist. Aborting...", webappId);
                 logger.log(Level.WARNING, msg);
                 throw new AREAsapiException(msg);
@@ -1257,7 +1257,7 @@ public class AsapiSupport {
             try {
                 // try to find autostart model
                 // First look for a model file names autostart.acs
-                File autostartModel = ResourceRegistry.toFile(ResourceRegistry.getInstance().getResource(AUTO_START_MODEL, RES_TYPE.MODEL));
+                File autostartModel = ResourceRegistry.getInstance().toFile(ResourceRegistry.getInstance().getResource(AUTO_START_MODEL, RES_TYPE.MODEL));
                 if (autostartModel.exists()) {
                     startModel = autostartModel.getPath();
                 } else {
@@ -1265,7 +1265,7 @@ public class AsapiSupport {
                     // only one existing or throw an error message
                     List<URI> models = ResourceRegistry.getInstance().getModelList(false);
                     if (models.size() == 1) {
-                        startModel = ResourceRegistry.toString(models.get(0));
+                        startModel = ResourceRegistry.getInstance().toString(models.get(0));
                     } else {
                         throw new AREAsapiException(
                                 "No model found for autostart. To define autostart model, either\n\ncreate model " + ResourceRegistry.MODELS_FOLDER

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/BundleManager.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/BundleManager.java
@@ -1,10 +1,7 @@
 package eu.asterics.mw.are;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -188,11 +185,11 @@ public class BundleManager implements BundleListener, FrameworkListener {
             componentTypeIDToJarName.clear();
             List<URI> jarNameURIList = ResourceRegistry.getInstance().getComponentJarList(false);
             for (URI jarNameURI : jarNameURIList) {
-                URI bundleDescriptorURI = ResourceRegistry.toJarInternalURI(jarNameURI, DefaultBundleModelParser.BUNDLE_DESCRIPTOR_RELATIVE_URI);
-                String bundleDescriptorAsXMLString = ResourceRegistry.getResourceContentAsString(bundleDescriptorURI.toURL().openStream());
+                URI bundleDescriptorURI = ResourceRegistry.getInstance().toJarInternalURI(jarNameURI, DefaultBundleModelParser.BUNDLE_DESCRIPTOR_RELATIVE_URI);
+                String bundleDescriptorAsXMLString = ResourceRegistry.getInstance().getResourceContentAsString(bundleDescriptorURI.toURL().openStream());
                 Set<IComponentType> componentTypeSet = DefaultBundleModelParser.instance.parseModelAsXMLString(bundleDescriptorAsXMLString);
                 for (IComponentType componentType : componentTypeSet) {
-                    componentTypeIDToJarName.put(componentType.getID(), ResourceRegistry.toString(ResourceRegistry.getInstance().toRelative(jarNameURI)));
+                    componentTypeIDToJarName.put(componentType.getID(), ResourceRegistry.getInstance().toString(ResourceRegistry.getInstance().toRelative(jarNameURI)));
                     ComponentRepository.instance.install(componentType);
                 }
             }
@@ -207,7 +204,7 @@ public class BundleManager implements BundleListener, FrameworkListener {
      */
     private boolean cacheFileMissing() {
         logger.fine("Checking missing cache files");
-        if (!ResourceRegistry.resourceExists(LOADER_COMPONENTLIST_CACHE_FILE_URI) || !ResourceRegistry.resourceExists(COMPONENT_COLLECTION_CACHE_FILE_URI)) {
+        if (!ResourceRegistry.getInstance().resourceExists(LOADER_COMPONENTLIST_CACHE_FILE_URI) || !ResourceRegistry.getInstance().resourceExists(COMPONENT_COLLECTION_CACHE_FILE_URI)) {
             return true;
         }
         return false;
@@ -420,7 +417,7 @@ public class BundleManager implements BundleListener, FrameworkListener {
         }
 
         try {
-            return ResourceRegistry.resourceExists(bundleDescriptorUrl.toURI());
+            return ResourceRegistry.getInstance().resourceExists(bundleDescriptorUrl.toURI());
         } catch (URISyntaxException e) {
             logger.warning("Could not check for Asterics metadata (bundle_descriptor.xml) due to invalid URI: " + bundleDescriptorUrl);
             return false;
@@ -448,7 +445,7 @@ public class BundleManager implements BundleListener, FrameworkListener {
         List<URI> bundleDescriptorURIs = new ArrayList<URI>();
         List<URI> componentJarURIs = ResourceRegistry.getInstance().getComponentJarList(false);
         for (URI componentJarURI : componentJarURIs) {
-            URI jarInternalURI = ResourceRegistry.toJarInternalURI(componentJarURI, DefaultBundleModelParser.BUNDLE_DESCRIPTOR_RELATIVE_URI);
+            URI jarInternalURI = ResourceRegistry.getInstance().toJarInternalURI(componentJarURI, DefaultBundleModelParser.BUNDLE_DESCRIPTOR_RELATIVE_URI);
 
             try {
                 if (checkForAstericsMetadata(jarInternalURI.toURL(), jarInternalURI.toString())) {
@@ -562,7 +559,7 @@ public class BundleManager implements BundleListener, FrameworkListener {
      */
     public URI getBundleDescriptorURIFromComponentTypeId(String componentTypeId) throws BundleManagementException {
         URI jarNameURI = getJarNameURIFromComponentTypeId(componentTypeId);
-        URI bundleDescriptorURI = ResourceRegistry.toJarInternalURI(jarNameURI, DefaultBundleModelParser.BUNDLE_DESCRIPTOR_RELATIVE_URI);
+        URI bundleDescriptorURI = ResourceRegistry.getInstance().toJarInternalURI(jarNameURI, DefaultBundleModelParser.BUNDLE_DESCRIPTOR_RELATIVE_URI);
         return bundleDescriptorURI;
     }
 
@@ -796,9 +793,9 @@ public class BundleManager implements BundleListener, FrameworkListener {
 
         StringWriter loaderComponentListWriter = new StringWriter();
         for (URI bundleURI : bundleURIList) {
-            URL bundleDescriptor = ResourceRegistry.toJarInternalURI(bundleURI, DefaultBundleModelParser.BUNDLE_DESCRIPTOR_RELATIVE_URI).toURL();
+            URL bundleDescriptor = ResourceRegistry.getInstance().toJarInternalURI(bundleURI, DefaultBundleModelParser.BUNDLE_DESCRIPTOR_RELATIVE_URI).toURL();
 
-            String bundleDescriptorAsXMLString = ResourceRegistry.getResourceContentAsString(bundleDescriptor.openStream());
+            String bundleDescriptorAsXMLString = ResourceRegistry.getInstance().getResourceContentAsString(bundleDescriptor.openStream());
             Set<IComponentType> componentTypeSet = DefaultBundleModelParser.instance.parseModelAsXMLString(bundleDescriptorAsXMLString);
 
             // update big bundle descriptors string
@@ -818,11 +815,11 @@ public class BundleManager implements BundleListener, FrameworkListener {
             }
         }
         // Write component list cache
-        ResourceRegistry.storeResource(loaderComponentListWriter.toString(), LOADER_COMPONENTLIST_CACHE_FILE_URI);
+        ResourceRegistry.getInstance().storeResource(loaderComponentListWriter.toString(), LOADER_COMPONENTLIST_CACHE_FILE_URI);
 
         // Finalize bundle descriptors string and store it into the cache file.
         bundleDescriptorsXMLBuilder.append("</componentTypes>");
-        ResourceRegistry.storeResource(bundleDescriptorsXMLBuilder.toString(), COMPONENT_COLLECTION_CACHE_FILE_URI);
+        ResourceRegistry.getInstance().storeResource(bundleDescriptorsXMLBuilder.toString(), COMPONENT_COLLECTION_CACHE_FILE_URI);
     }
 
     /**
@@ -880,7 +877,7 @@ public class BundleManager implements BundleListener, FrameworkListener {
         try {
             // String inputFilePath = "jar:file://" + serviceBundleURI.getPath()
             // + "!/bundle_descriptor.xml" ;
-            URI jarInternalURI = ResourceRegistry.toJarInternalURI(serviceBundleURI, DefaultBundleModelParser.BUNDLE_DESCRIPTOR_RELATIVE_URI);
+            URI jarInternalURI = ResourceRegistry.getInstance().toJarInternalURI(serviceBundleURI, DefaultBundleModelParser.BUNDLE_DESCRIPTOR_RELATIVE_URI);
 
             if (checkForAstericsMetadata(jarInternalURI.toURL(), jarInternalURI.toString())) {
                 // if it has a bundle_descirptor it can only be a component
@@ -890,7 +887,7 @@ public class BundleManager implements BundleListener, FrameworkListener {
 
             // inputFilePath = "jar:file://" + serviceBundleURI.getPath() +
             // "!/META-INF/MANIFEST.MF" ;
-            jarInternalURI = ResourceRegistry.toJarInternalURI(serviceBundleURI, "/META-INF/MANIFEST.MF");
+            jarInternalURI = ResourceRegistry.getInstance().toJarInternalURI(serviceBundleURI, "/META-INF/MANIFEST.MF");
 
             try (BufferedReader in = new BufferedReader(new InputStreamReader(jarInternalURI.toURL().openStream()))) {
                 String actLine = "";

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/parsers/DefaultBundleModelParser.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/parsers/DefaultBundleModelParser.java
@@ -2,12 +2,10 @@ package eu.asterics.mw.are.parsers;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -132,7 +130,7 @@ public class DefaultBundleModelParser {
      * @throws IOException 
      */
     public Set<IComponentType> parseModel(InputStream inputStream) throws ParseException, IOException {
-        String bundleDescriptorAsXMLString=ResourceRegistry.getResourceContentAsString(inputStream);
+        String bundleDescriptorAsXMLString= ResourceRegistry.getInstance().getResourceContentAsString(inputStream);
         return parseModelAsXMLString(bundleDescriptorAsXMLString);        
     }
 
@@ -193,7 +191,7 @@ public class DefaultBundleModelParser {
      */
     public String getBundleDescriptionOfComponentTypeId(String componentTypeId, InputStream inputStream)
             throws ParserConfigurationException, SAXException, IOException {
-        String bundleDescriptorAsXMLString=ResourceRegistry.getResourceContentAsString(inputStream);
+        String bundleDescriptorAsXMLString= ResourceRegistry.getInstance().getResourceContentAsString(inputStream);
         
         final DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
 

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/parsers/DefaultDeploymentModelParser.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/parsers/DefaultDeploymentModelParser.java
@@ -1,14 +1,11 @@
 package eu.asterics.mw.are.parsers;
 
 import java.awt.Point;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -152,7 +149,7 @@ public class DefaultDeploymentModelParser {
      */
     public DefaultRuntimeModel parseModel(final InputStream modelInputStream)
             throws ParseException, BundleManagementException, IOException {
-        String modelAsXMLString=ResourceRegistry.getResourceContentAsString(modelInputStream);
+        String modelAsXMLString= ResourceRegistry.getInstance().getResourceContentAsString(modelInputStream);
         return parseModelAsXMLString(modelAsXMLString);
     }
     

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/parsers/ModelValidator.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/parsers/ModelValidator.java
@@ -69,10 +69,10 @@ public class ModelValidator {
     private static ModelValidator instance = null;
 
     public ModelValidator() throws MalformedURLException {
-        this(ResourceRegistry
+        this(ResourceRegistry.getInstance()
                 .toJarInternalURI(ResourceRegistry.getInstance().getAREJarURI(false), BUNDLE_DESCRIPTOR_SCHEMA_URL)
                 .toURL(),
-                ResourceRegistry.toJarInternalURI(ResourceRegistry.getInstance().getAREJarURI(false),
+                ResourceRegistry.getInstance().toJarInternalURI(ResourceRegistry.getInstance().getAREJarURI(false),
                         DEPLOYMENT_DESCRIPTOR_SCHEMA_URL).toURL());
     }
 

--- a/ARE/middleware/src/main/java/eu/asterics/mw/services/ResourceRegistry.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/services/ResourceRegistry.java
@@ -118,6 +118,351 @@ public class ResourceRegistry {
         AstericsErrorHandling.instance.getLogger().fine("Setting OSGI_MODE to <" + OSGI_MODE + ">");
     }
 
+    /**
+     * Creates an absolute URI defining a resource within a jarFileURI.
+     *
+     * @param jarFileURI
+     *            The jarFileURI that contains the resource.
+     * @param relativeInternalURI
+     *            The relative path to the resource within the jar file. The relative path must have a leading / (e.g. /bundle_descriptor.xml)
+     * @return
+     */
+    public URI toJarInternalURI(URI jarFileURI, String relativeInternalURI) {
+        String jarInternalURI = "jar:" + jarFileURI + "!" + relativeInternalURI;
+        return URI.create(jarInternalURI);
+    }
+
+    /**
+     * Return the String representation of the given URI.
+     *
+     * @param uri
+     * @return
+     */
+    public String toString(URI uri) {
+        return uri.getPath();
+    }
+
+    /**
+     * Returns a List of Strings representing URI paths.
+     *
+     * @param uris
+     * @return
+     */
+    public List<String> toStringList(Collection<URI> uris) {
+        List<String> result = new ArrayList<String>();
+        for (URI uri : uris) {
+            result.add(ResourceRegistry.toString(uri));
+        }
+        return result;
+    }
+
+    /**
+     * Returns a Set of Strings representing URI paths.
+     *
+     * @param uris
+     * @return
+     */
+    public Set<String> toStringSet(Collection<URI> uris) {
+        Set<String> result = new TreeSet<String>();
+        for (URI uri : uris) {
+            result.add(ResourceRegistry.toString(uri));
+        }
+        return result;
+    }
+
+    /**
+     * Returns an array of Strings representing URI paths.
+     *
+     * @param uris
+     * @return
+     */
+    public String[] toStringArray(Collection<URI> uris) {
+        String[] result = new String[uris.size()];
+        int i = 0;
+        for (URI uri : uris) {
+            result[i] = ResourceRegistry.toString(uri);
+            i++;
+        }
+        return result;
+    }
+
+    /**
+     * Returns a list of model URIs in the given model dir URI.
+     *
+     * @param modelDirURI
+     * @param relative
+     *            true: Only return name without absolute path.
+     * @return
+     */
+    public List<URI> getModelList(URI modelDirURI, boolean relative) {
+        // get asterics involved model files
+        // Not sure how deep we should search, but 10 seems to be enough
+        List<URI> URIs = ComponentUtils.findFiles(modelDirURI, relative, RECURSIVE_FILE_SEARCH_DEPTH, new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name != null && name.endsWith(".acs");
+            }
+        });
+        return URIs;
+    }
+
+    public Path toPath(URI uri) throws URISyntaxException {
+        String scheme = uri.getScheme();
+        if (scheme != null && !scheme.startsWith("file")) {
+            throw new URISyntaxException(uri.toString(), "The uri does not start with the scheme <file>");
+        }
+        Path p = ResourceRegistry.getInstance().toFile(uri).toPath();
+        return p;
+    }
+
+    /**
+     * Returns a File object representing the given URI if possible. This only works if the given URI is a relative path or is a path with a file scheme
+     * (starting with: file)
+     *
+     * @param uri
+     * @return
+     * @throws URISyntaxException
+     */
+    public File toFile(URI uri) throws URISyntaxException {
+        String scheme = uri.getScheme();
+        if (scheme != null && !scheme.startsWith("file")) {
+            throw new URISyntaxException(uri.toString(), "The uri does not start with the scheme <file>");
+        }
+        File f = new File(uri.getPath());
+        return f;
+    }
+
+    /**
+     * Checks whether the given URI is a URL or not.
+     *
+     * @param uriToCheck
+     *            true: URI is a URL, false: URI is not a URL but probably a file (relative or absolute)
+     * @return
+     */
+    public boolean isURL(URI uriToCheck) {
+        try {
+            uriToCheck.toURL();
+            return true;
+        } catch (MalformedURLException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the file/directory name of a given URI. This method simply splits the URI.getPath into elements seperated by a slash (/) and returns the last
+     * element.
+     *
+     * @param absolutePath
+     * @return
+     */
+    public String getLastElementOfURI(URI absolutePath) {
+        String[] elems = absolutePath.getPath().split("/");
+        if (elems != null && elems.length > 0) {
+            return elems[elems.length - 1];
+        }
+        return "";
+    }
+
+    /**
+     * Stores the given data to the given OutputStream and encoded as {@link ResourceRegistry#ARE_FILE_ENCODING}. The OutputStream is automatically closed
+     * afterwards.
+     *
+     * @param data
+     * @param outputStream
+     * @throws IOException
+     */
+    public void storeResource(String data, OutputStream outputStream) throws IOException {
+        try {
+            IOUtils.write(data, outputStream, ResourceRegistry.ARE_FILE_ENCODING);
+        } finally {
+            outputStream.flush();
+            outputStream.close();
+        }
+    }
+
+    /**
+     * Stores the given data at the given File object and encoded as {@link ResourceRegistry#ARE_FILE_ENCODING}.
+     *
+     * @param data
+     * @param storeResourceFile
+     * @throws IOException
+     */
+    // Made this method private to not tempt developers to directly create File object paths and store to it.
+    private void storeResource(String data, File storeResourceFile) throws IOException {
+        File parentDir = storeResourceFile.getParentFile();
+        if (!parentDir.exists()) {
+            if (!parentDir.mkdirs()) {
+                logger.severe("Could not create parent directories for data file: " + storeResourceFile);
+                throw new IOException("Could not create parent directories for data file.");
+            }
+        }
+        storeResource(data, new FileOutputStream(storeResourceFile));
+    }
+
+    /**
+     * Stores the given data at the given URI and encoded as {@link ResourceRegistry#ARE_FILE_ENCODING}.
+     *
+     * @param data
+     * @param storeResourceURI
+     * @throws URISyntaxException
+     * @throws IOException
+     */
+    public void storeResource(String data, URI storeResourceURI) throws URISyntaxException, IOException {
+        storeResource(data, ResourceRegistry.toFile(storeResourceURI));
+    }
+
+    /**
+     * Helper method to convert an InputStream to a String. The content of the InputStream is expected to be encoded in
+     * {@link ResourceRegistry#ARE_FILE_ENCODING}. The method automatically closes the given InputStream instance.
+     *
+     * @param inputStream
+     * @return
+     * @throws IOException
+     */
+    public String getResourceContentAsString(InputStream inputStream) throws IOException {
+        /*
+         * Use the IOUtils class of apache commons, makes it easier to deal with encodings. We encapsulate the inputStream into a BOMInputStream to exclude an
+         * optional BOM:
+         *
+         * @link http://www.rgagnon.com/javadetails/java-handle-utf8-file-with-bom.html
+         *
+         * @link https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/input/BOMInputStream.html
+         */
+        try {
+            String modelAsString = IOUtils.toString(new BOMInputStream(inputStream), ResourceRegistry.ARE_FILE_ENCODING);
+            return modelAsString;
+        } finally {
+            inputStream.close();
+        }
+    }
+
+    /**
+     * Tests whether the given URI exists by 1) testing if it is a File and invoking the File.exists method 2) trying to open an InputStream
+     *
+     * @param uri
+     * @return
+     */
+    public boolean resourceExists(URI uri) {
+        try {
+            if (ResourceRegistry.toFile(uri).exists()) {
+                return true;
+            }
+        } catch (URISyntaxException e) {
+            InputStream in = null;
+            try {
+                in = uri.toURL().openStream();
+                return true;
+            } catch (IOException e1) {
+            } finally {
+                if (in != null) {
+                    try {
+                        in.close();
+                    } catch (IOException e1) {
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the given uri points to a subpath of the given baseURI URI.
+     *
+     * @param baseURI
+     * @param toTest
+     * @return
+     */
+    public boolean isSubURI(URI baseURI, URI toTest) {
+        URI relativeURI = baseURI.normalize().relativize(toTest.normalize());
+        return !relativeURI.isAbsolute();
+    }
+
+    /**
+     * Compares equalness of the given URIs. Before comparison the URIs are normalized.
+     *
+     * @param first
+     * @param second
+     * @return
+     */
+    public boolean equalsNormalizedURIs(URI first, URI second) {
+        first.normalize();
+        second.normalize();
+        return first.normalize().equals(second.normalize());
+    }
+
+    /**
+     * Resolves the given nonURIConformingFilePath to the given baseURI URI. The string may contain normal file path characters like space and supports \\ and /
+     * as seperators if parameter slashify=true
+     *
+     * @param baseURIPath
+     * @param nonURIConformingFilePath
+     * @param slashify
+     *            true: Convert seperators to unix-style /
+     * @return
+     */
+    public File resolveRelativeFilePath(File baseURIPath, String nonURIConformingFilePath, boolean slashify) {
+        if (slashify) {
+            nonURIConformingFilePath = FilenameUtils.separatorsToUnix(nonURIConformingFilePath);
+        }
+
+        File absFile = new File(nonURIConformingFilePath);
+        if (!absFile.isAbsolute()) {
+            absFile = new File(baseURIPath, nonURIConformingFilePath);
+        }
+        return absFile;
+    }
+
+    /**
+     * Resolves the given nonURIConformingFilePath to the given baseURI URI. The string may contain normal file path characters like space and supports \\ and /
+     * as seperators.
+     *
+     * @param baseURIPath
+     * @param nonURIConformingFilePath
+     * @return
+     */
+    public File resolveRelativeFilePath(File baseURIPath, String nonURIConformingFilePath) {
+        return resolveRelativeFilePath(baseURIPath, nonURIConformingFilePath, true);
+    }
+
+    /**
+     * Resolves the given nonURIConformingFilePath to the given baseURI URI. The string may contain normal file path characters like space and supports \\ and /
+     * as seperators if parameter slashify=true
+     *
+     * @param baseURIPath
+     * @param nonURIConformingFilePath
+     * @param slashify
+     *            true: Convert seperators to unix-style /
+     * @return
+     */
+    public File resolveRelativeFilePath(URI baseURIPath, String nonURIConformingFilePath, boolean slashify) {
+        if (slashify) {
+            nonURIConformingFilePath = FilenameUtils.separatorsToUnix(nonURIConformingFilePath);
+        }
+        // File resolvedFile=new File(new
+        // File(baseURI),nonURIConformingFilePath);
+        // return resolvedFile;
+
+        File absFile = new File(nonURIConformingFilePath);
+        if (!absFile.isAbsolute()) {
+            absFile = new File(new File(baseURIPath), nonURIConformingFilePath);
+        }
+        return absFile;
+
+    }
+
+    /**
+     * Resolves the given nonURIConformingFilePath to the given baseURI URI. The string may contain normal file path characters like space and supports \\ and /
+     * as seperators.
+     *
+     * @param baseURI
+     * @param nonURIConformingFilePath
+     * @return
+     */
+    public File resolveRelativeFilePath(URI baseURI, String nonURIConformingFilePath) {
+        return resolveRelativeFilePath(baseURI, nonURIConformingFilePath, true);
+    }
+
     public enum RES_TYPE {
         ANY, MODEL, DATA, JAR, PROFILE, STORAGE, LICENSE, IMAGE, TMP, WEB_DOCUMENT_ROOT
     };
@@ -161,6 +506,7 @@ public class ResourceRegistry {
      * @return
      */
     public static ResourceRegistry getInstance() {
+
         return instance;
     }
 
@@ -372,78 +718,6 @@ public class ResourceRegistry {
     }
 
     /**
-     * Resolves the given nonURIConformingFilePath to the given baseURI URI. The string may contain normal file path characters like space and supports \\ and /
-     * as seperators.
-     * 
-     * @param baseURI
-     * @param nonURIConformingFilePath
-     * @return
-     */
-    public static File resolveRelativeFilePath(URI baseURI, String nonURIConformingFilePath) {
-        return resolveRelativeFilePath(baseURI, nonURIConformingFilePath, true);
-    }
-
-    /**
-     * Resolves the given nonURIConformingFilePath to the given baseURI URI. The string may contain normal file path characters like space and supports \\ and /
-     * as seperators if parameter slashify=true
-     * 
-     * @param baseURIPath
-     * @param nonURIConformingFilePath
-     * @param slashify
-     *            true: Convert seperators to unix-style /
-     * @return
-     */
-    public static File resolveRelativeFilePath(URI baseURIPath, String nonURIConformingFilePath, boolean slashify) {
-        if (slashify) {
-            nonURIConformingFilePath = FilenameUtils.separatorsToUnix(nonURIConformingFilePath);
-        }
-        // File resolvedFile=new File(new
-        // File(baseURI),nonURIConformingFilePath);
-        // return resolvedFile;
-
-        File absFile = new File(nonURIConformingFilePath);
-        if (!absFile.isAbsolute()) {
-            absFile = new File(new File(baseURIPath), nonURIConformingFilePath);
-        }
-        return absFile;
-
-    }
-
-    /**
-     * Resolves the given nonURIConformingFilePath to the given baseURI URI. The string may contain normal file path characters like space and supports \\ and /
-     * as seperators.
-     * 
-     * @param baseURIPath
-     * @param nonURIConformingFilePath
-     * @return
-     */
-    public static File resolveRelativeFilePath(File baseURIPath, String nonURIConformingFilePath) {
-        return resolveRelativeFilePath(baseURIPath, nonURIConformingFilePath, true);
-    }
-
-    /**
-     * Resolves the given nonURIConformingFilePath to the given baseURI URI. The string may contain normal file path characters like space and supports \\ and /
-     * as seperators if parameter slashify=true
-     * 
-     * @param baseURIPath
-     * @param nonURIConformingFilePath
-     * @param slashify
-     *            true: Convert seperators to unix-style /
-     * @return
-     */
-    public static File resolveRelativeFilePath(File baseURIPath, String nonURIConformingFilePath, boolean slashify) {
-        if (slashify) {
-            nonURIConformingFilePath = FilenameUtils.separatorsToUnix(nonURIConformingFilePath);
-        }
-
-        File absFile = new File(nonURIConformingFilePath);
-        if (!absFile.isAbsolute()) {
-            absFile = new File(baseURIPath, nonURIConformingFilePath);
-        }
-        return absFile;
-    }
-
-    /**
      * Compares equalness of the given uri to the ARE.baseURI. Before comparison the URIs are normalized.
      * 
      * @param uri
@@ -461,61 +735,6 @@ public class ResourceRegistry {
      */
     public boolean isSubURIOfAREBaseURI(URI uri) {
         return isSubURI(getAREBaseURI(), uri);
-    }
-
-    /**
-     * Compares equalness of the given URIs. Before comparison the URIs are normalized.
-     * 
-     * @param first
-     * @param second
-     * @return
-     */
-    public static boolean equalsNormalizedURIs(URI first, URI second) {
-        first.normalize();
-        second.normalize();
-        return first.normalize().equals(second.normalize());
-    }
-
-    /**
-     * Checks if the given uri points to a subpath of the given baseURI URI.
-     * 
-     * @param baseURI
-     * @param toTest
-     * @return
-     */
-    public static boolean isSubURI(URI baseURI, URI toTest) {
-        URI relativeURI = baseURI.normalize().relativize(toTest.normalize());
-        return !relativeURI.isAbsolute();
-    }
-
-    /**
-     * Tests whether the given URI exists by 1) testing if it is a File and invoking the File.exists method 2) trying to open an InputStream
-     * 
-     * @param uri
-     * @return
-     */
-    public static boolean resourceExists(URI uri) {
-        try {
-            if (ResourceRegistry.toFile(uri).exists()) {
-                return true;
-            }
-        } catch (URISyntaxException e) {
-            InputStream in = null;
-            try {
-                in = uri.toURL().openStream();
-                return true;
-            } catch (IOException e1) {
-            } finally {
-                if (in != null) {
-                    try {
-                        in.close();
-                    } catch (IOException e1) {
-                    }
-                }
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -589,31 +808,6 @@ public class ResourceRegistry {
     }
 
     /**
-     * Helper method to convert an InputStream to a String. The content of the InputStream is expected to be encoded in
-     * {@link ResourceRegistry#ARE_FILE_ENCODING}. The method automatically closes the given InputStream instance.
-     *
-     * @param inputStream
-     * @return
-     * @throws IOException
-     */
-    public static String getResourceContentAsString(InputStream inputStream) throws IOException {
-        /*
-         * Use the IOUtils class of apache commons, makes it easier to deal with encodings. We encapsulate the inputStream into a BOMInputStream to exclude an
-         * optional BOM:
-         * 
-         * @link http://www.rgagnon.com/javadetails/java-handle-utf8-file-with-bom.html
-         * 
-         * @link https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/input/BOMInputStream.html
-         */
-        try {
-            String modelAsString = IOUtils.toString(new BOMInputStream(inputStream), ResourceRegistry.ARE_FILE_ENCODING);
-            return modelAsString;
-        } finally {
-            inputStream.close();
-        }
-    }
-
-    /**
      * Stores data to a given resource path in a given resource-Type directory defined by {@link ResourceRegistry#RES_TYPE}.
      *
      * @param data
@@ -631,54 +825,6 @@ public class ResourceRegistry {
     public void storeResource(String data, String resourcePath, RES_TYPE resourceType)
             throws URISyntaxException, FileNotFoundException, IOException {
         storeResource(data, ResourceRegistry.getInstance().getResource(resourcePath, resourceType));
-    }
-
-    /**
-     * Stores the given data at the given URI and encoded as {@link ResourceRegistry#ARE_FILE_ENCODING}.
-     * 
-     * @param data
-     * @param storeResourceURI
-     * @throws URISyntaxException
-     * @throws IOException
-     */
-    public static void storeResource(String data, URI storeResourceURI) throws URISyntaxException, IOException {
-        storeResource(data, ResourceRegistry.toFile(storeResourceURI));
-    }
-
-    /**
-     * Stores the given data at the given File object and encoded as {@link ResourceRegistry#ARE_FILE_ENCODING}.
-     * 
-     * @param data
-     * @param storeResourceFile
-     * @throws IOException
-     */
-    // Made this method private to not tempt developers to directly create File object paths and store to it.
-    private static void storeResource(String data, File storeResourceFile) throws IOException {
-        File parentDir = storeResourceFile.getParentFile();
-        if (!parentDir.exists()) {
-            if (!parentDir.mkdirs()) {
-                logger.severe("Could not create parent directories for data file: " + storeResourceFile);
-                throw new IOException("Could not create parent directories for data file.");
-            }
-        }
-        storeResource(data, new FileOutputStream(storeResourceFile));
-    }
-
-    /**
-     * Stores the given data to the given OutputStream and encoded as {@link ResourceRegistry#ARE_FILE_ENCODING}. The OutputStream is automatically closed
-     * afterwards.
-     * 
-     * @param data
-     * @param outputStream
-     * @throws IOException
-     */
-    public static void storeResource(String data, OutputStream outputStream) throws IOException {
-        try {
-            IOUtils.write(data, outputStream, ResourceRegistry.ARE_FILE_ENCODING);
-        } finally {
-            outputStream.flush();
-            outputStream.close();
-        }
     }
 
     // public void setAREBaseURI()
@@ -767,21 +913,6 @@ public class ResourceRegistry {
     }
 
     /**
-     * Returns the file/directory name of a given URI. This method simply splits the URI.getPath into elements seperated by a slash (/) and returns the last
-     * element.
-     * 
-     * @param absolutePath
-     * @return
-     */
-    public static String getLastElementOfURI(URI absolutePath) {
-        String[] elems = absolutePath.getPath().split("/");
-        if (elems != null && elems.length > 0) {
-            return elems[elems.length - 1];
-        }
-        return "";
-    }
-
-    /**
      * Converts the given relativePath to an absolute path by resolving with the ARE base URI {@link getAREBaseURI}.
      * 
      * @param relativePath
@@ -799,48 +930,6 @@ public class ResourceRegistry {
      */
     public URI toAbsolute(URI relativePath) {
         return getAREBaseURI().resolve(relativePath);
-    }
-
-    /**
-     * Checks whether the given URI is a URL or not.
-     * 
-     * @param uriToCheck
-     *            true: URI is a URL, false: URI is not a URL but probably a file (relative or absolute)
-     * @return
-     */
-    public static boolean isURL(URI uriToCheck) {
-        try {
-            uriToCheck.toURL();
-            return true;
-        } catch (MalformedURLException e) {
-            return false;
-        }
-    }
-
-    /**
-     * Returns a File object representing the given URI if possible. This only works if the given URI is a relative path or is a path with a file scheme
-     * (starting with: file)
-     * 
-     * @param uri
-     * @return
-     * @throws URISyntaxException
-     */
-    public static File toFile(URI uri) throws URISyntaxException {
-        String scheme = uri.getScheme();
-        if (scheme != null && !scheme.startsWith("file")) {
-            throw new URISyntaxException(uri.toString(), "The uri does not start with the scheme <file>");
-        }
-        File f = new File(uri.getPath());
-        return f;
-    }
-
-    public static Path toPath(URI uri) throws URISyntaxException {
-        String scheme = uri.getScheme();
-        if (scheme != null && !scheme.startsWith("file")) {
-            throw new URISyntaxException(uri.toString(), "The uri does not start with the scheme <file>");
-        }
-        Path p = toFile(uri).toPath();
-        return p;
     }
 
     /**
@@ -1166,26 +1255,6 @@ public class ResourceRegistry {
     }
 
     /**
-     * Returns a list of model URIs in the given model dir URI.
-     * 
-     * @param modelDirURI
-     * @param relative
-     *            true: Only return name without absolute path.
-     * @return
-     */
-    public static List<URI> getModelList(URI modelDirURI, boolean relative) {
-        // get asterics involved model files
-        // Not sure how deep we should search, but 10 seems to be enough
-        List<URI> URIs = ComponentUtils.findFiles(modelDirURI, relative, RECURSIVE_FILE_SEARCH_DEPTH, new FilenameFilter() {
-            @Override
-            public boolean accept(File dir, String name) {
-                return name != null && name.endsWith(".acs");
-            }
-        });
-        return URIs;
-    }
-
-    /**
      * Returns the ARE base URI as a File object, if possible.
      * 
      * @return
@@ -1199,71 +1268,4 @@ public class ResourceRegistry {
         // return null;
     }
 
-    /**
-     * Returns an array of Strings representing URI paths.
-     * 
-     * @param uris
-     * @return
-     */
-    public static String[] toStringArray(Collection<URI> uris) {
-        String[] result = new String[uris.size()];
-        int i = 0;
-        for (URI uri : uris) {
-            result[i] = ResourceRegistry.toString(uri);
-            i++;
-        }
-        return result;
-    }
-
-    /**
-     * Returns a Set of Strings representing URI paths.
-     * 
-     * @param uris
-     * @return
-     */
-    public static Set<String> toStringSet(Collection<URI> uris) {
-        Set<String> result = new TreeSet<String>();
-        for (URI uri : uris) {
-            result.add(ResourceRegistry.toString(uri));
-        }
-        return result;
-    }
-
-    /**
-     * Returns a List of Strings representing URI paths.
-     * 
-     * @param uris
-     * @return
-     */
-    public static List<String> toStringList(Collection<URI> uris) {
-        List<String> result = new ArrayList<String>();
-        for (URI uri : uris) {
-            result.add(ResourceRegistry.toString(uri));
-        }
-        return result;
-    }
-
-    /**
-     * Return the String representation of the given URI.
-     * 
-     * @param uri
-     * @return
-     */
-    public static String toString(URI uri) {
-        return uri.getPath();
-    }
-
-    /**
-     * Creates an absolute URI defining a resource within a jarFileURI.
-     * 
-     * @param jarFileURI
-     *            The jarFileURI that contains the resource.
-     * @param relativeInternalURI
-     *            The relative path to the resource within the jar file. The relative path must have a leading / (e.g. /bundle_descriptor.xml)
-     * @return
-     */
-    public static URI toJarInternalURI(URI jarFileURI, String relativeInternalURI) {
-        String jarInternalURI = "jar:" + jarFileURI + "!" + relativeInternalURI;
-        return URI.create(jarInternalURI);
-    }
 }

--- a/ARE/middleware/src/main/java/eu/asterics/mw/services/ResourceRegistry.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/services/ResourceRegistry.java
@@ -99,8 +99,8 @@ public class ResourceRegistry {
     static {
         URI defaultAREBaseURI = Paths.get(".").toUri();
         try {
-            defaultAREBaseURI = ResourceRegistry.toPath(ResourceRegistry.instance.getClass().getProtectionDomain().getCodeSource().getLocation().toURI())
-                    .getParent().toUri();
+            defaultAREBaseURI = ResourceRegistry
+                    .toPathInternal(ResourceRegistry.instance.getClass().getProtectionDomain().getCodeSource().getLocation().toURI()).getParent().toUri();
         } catch (URISyntaxException e) {
         }
         ARE_BASE_URI = URI.create(System.getProperty("eu.asterics.ARE.baseURI", defaultAREBaseURI.toString()));
@@ -151,7 +151,7 @@ public class ResourceRegistry {
     public List<String> toStringList(Collection<URI> uris) {
         List<String> result = new ArrayList<String>();
         for (URI uri : uris) {
-            result.add(ResourceRegistry.toString(uri));
+            result.add(ResourceRegistry.getInstance().toString(uri));
         }
         return result;
     }
@@ -165,7 +165,7 @@ public class ResourceRegistry {
     public Set<String> toStringSet(Collection<URI> uris) {
         Set<String> result = new TreeSet<String>();
         for (URI uri : uris) {
-            result.add(ResourceRegistry.toString(uri));
+            result.add(ResourceRegistry.getInstance().toString(uri));
         }
         return result;
     }
@@ -180,7 +180,7 @@ public class ResourceRegistry {
         String[] result = new String[uris.size()];
         int i = 0;
         for (URI uri : uris) {
-            result[i] = ResourceRegistry.toString(uri);
+            result[i] = ResourceRegistry.getInstance().toString(uri);
             i++;
         }
         return result;
@@ -206,13 +206,34 @@ public class ResourceRegistry {
         return URIs;
     }
 
-    public Path toPath(URI uri) throws URISyntaxException {
+    static Path toPathInternal(URI uri) throws URISyntaxException {
         String scheme = uri.getScheme();
         if (scheme != null && !scheme.startsWith("file")) {
             throw new URISyntaxException(uri.toString(), "The uri does not start with the scheme <file>");
         }
-        Path p = ResourceRegistry.getInstance().toFile(uri).toPath();
+        Path p = ResourceRegistry.toFileInternal(uri).toPath();
         return p;
+    }
+
+    /**
+     * Converts the given URI object into a Patch object. Checks if the given URI has the file protocol as scheme and otherwise throws a @link
+     * {@link URISyntaxException}.
+     * 
+     * @param uri
+     * @return
+     * @throws URISyntaxException
+     */
+    public Path toPath(URI uri) throws URISyntaxException {
+        return toPathInternal(uri);
+    }
+
+    static File toFileInternal(URI uri) throws URISyntaxException {
+        String scheme = uri.getScheme();
+        if (scheme != null && !scheme.startsWith("file")) {
+            throw new URISyntaxException(uri.toString(), "The uri does not start with the scheme <file>");
+        }
+        File f = new File(uri.getPath());
+        return f;
     }
 
     /**
@@ -224,12 +245,7 @@ public class ResourceRegistry {
      * @throws URISyntaxException
      */
     public File toFile(URI uri) throws URISyntaxException {
-        String scheme = uri.getScheme();
-        if (scheme != null && !scheme.startsWith("file")) {
-            throw new URISyntaxException(uri.toString(), "The uri does not start with the scheme <file>");
-        }
-        File f = new File(uri.getPath());
-        return f;
+        return toFileInternal(uri);
     }
 
     /**
@@ -308,7 +324,7 @@ public class ResourceRegistry {
      * @throws IOException
      */
     public void storeResource(String data, URI storeResourceURI) throws URISyntaxException, IOException {
-        storeResource(data, ResourceRegistry.toFile(storeResourceURI));
+        storeResource(data, ResourceRegistry.getInstance().toFile(storeResourceURI));
     }
 
     /**
@@ -344,7 +360,7 @@ public class ResourceRegistry {
      */
     public boolean resourceExists(URI uri) {
         try {
-            if (ResourceRegistry.toFile(uri).exists()) {
+            if (ResourceRegistry.getInstance().toFile(uri).exists()) {
                 return true;
             }
         } catch (URISyntaxException e) {
@@ -597,7 +613,7 @@ public class ResourceRegistry {
                      * resolve against the given resourceName, if it exists return
                      */
                     URI dataFolderURI = toAbsolute(DATA_FOLDER);
-                    File dataFolderFile = ResourceRegistry.toFile(dataFolderURI);
+                    File dataFolderFile = ResourceRegistry.getInstance().toFile(dataFolderURI);
 
                     // 1) Check resourceName directly, if it exists return
                     resFilePath = resolveRelativeFilePath(dataFolderFile, resourcePathSlashified, false);
@@ -822,8 +838,7 @@ public class ResourceRegistry {
      * @throws IOException
      * @throws FileNotFoundException
      */
-    public void storeResource(String data, String resourcePath, RES_TYPE resourceType)
-            throws URISyntaxException, FileNotFoundException, IOException {
+    public void storeResource(String data, String resourcePath, RES_TYPE resourceType) throws URISyntaxException, FileNotFoundException, IOException {
         storeResource(data, ResourceRegistry.getInstance().getResource(resourcePath, resourceType));
     }
 
@@ -1225,9 +1240,10 @@ public class ResourceRegistry {
         });
         return URIs;
     }
-    
+
     /**
-     * Returns a list of URIs of all web 
+     * Returns a list of URIs of all web
+     * 
      * @param relative
      * @return
      */
@@ -1240,7 +1256,7 @@ public class ResourceRegistry {
                 return true;
             }
         });
-        return URIs;        
+        return URIs;
     }
 
     /**

--- a/ARE/tools/APE/src/main/java/eu/asterics/ape/main/APE.java
+++ b/ARE/tools/APE/src/main/java/eu/asterics/ape/main/APE.java
@@ -134,7 +134,7 @@ public class APE {
         URI defaultAPEBaseURI = new File(".").toURI();
         Notifier.debug("Current working dir: " + defaultAPEBaseURI, null);
         try {
-            defaultAPEBaseURI = ResourceRegistry
+            defaultAPEBaseURI = ResourceRegistry.getInstance()
                     .toFile(APE.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile()
                     .toURI();
             Notifier.debug("Location of APE.jar: " + defaultAPEBaseURI, null);
@@ -185,7 +185,7 @@ public class APE {
             SAXException, TransformerException, BundleManagementException, APEConfigurationException {
         ResourceRegistry.getInstance().setOSGIMode(false);
 
-        projectDir = ResourceRegistry.resolveRelativeFilePath(getAPEBaseURI(), DEFAULT_PROJECT_DIR);
+        projectDir = ResourceRegistry.getInstance().resolveRelativeFilePath(getAPEBaseURI(), DEFAULT_PROJECT_DIR);
 
         String customProjectDir = System.getProperty(P_APE_PROJECT_DIR);
         if (customProjectDir != null && !"".equals(customProjectDir)) {
@@ -198,17 +198,17 @@ public class APE {
             Notifier.info("Project folder does not exist, copying template to: " + projectDir);
             // If the projectDir does not exist, we should copy the template dir
             // to the projectDir
-            FileUtils.copyDirectory(ResourceRegistry.resolveRelativeFilePath(getAPEBaseURI(), Packager.TEMPLATE_FOLDER),
+            FileUtils.copyDirectory(ResourceRegistry.getInstance().resolveRelativeFilePath(getAPEBaseURI(), Packager.TEMPLATE_FOLDER),
                     projectDir);
         }
 
         initProperties();
 
         String newAreBaseURIString = apeProperties.getProperty(APEProperties.P_ARE_BASE_URI,
-                ResourceRegistry.resolveRelativeFilePath(getAPEBaseURI(), "../ARE/").getPath());
+                ResourceRegistry.getInstance().resolveRelativeFilePath(getAPEBaseURI(), "../ARE/").getPath());
 
         if (newAreBaseURIString != null) {
-            URI newAREBaseURI = ResourceRegistry.resolveRelativeFilePath(projectDir, newAreBaseURIString).toURI();
+            URI newAREBaseURI = ResourceRegistry.getInstance().resolveRelativeFilePath(projectDir, newAreBaseURIString).toURI();
             Notifier.debug("ApeProp[" + APEProperties.P_ARE_BASE_URI + "]=" + newAREBaseURI, null);
             ResourceRegistry.getInstance().setAREBaseURI(newAREBaseURI);
         }
@@ -238,7 +238,7 @@ public class APE {
 
         try {
             // APE.properties is expected to be in the project directory
-            URI apePropFileURI = ResourceRegistry.resolveRelativeFilePath(projectDir, "APE.properties").toURI();
+            URI apePropFileURI = ResourceRegistry.getInstance().resolveRelativeFilePath(projectDir, "APE.properties").toURI();
 
             defaultProperties.load(new BufferedReader(new InputStreamReader(apePropFileURI.toURL().openStream())));
             Notifier.debug("defaultProperties: " + defaultProperties.toString(), null);
@@ -273,7 +273,7 @@ public class APE {
             // Now adding default models search path to APE.models property
             Notifier.debug("Adding APE.projectDir/" + Packager.CUSTOM_BIN_ARE_FOLDER
                     + " as search path for model files to " + APEProperties.P_APE_MODELS, null);
-            String projectDirSearchPath = ResourceRegistry
+            String projectDirSearchPath = ResourceRegistry.getInstance()
                     .resolveRelativeFilePath(projectDir, Packager.CUSTOM_BIN_ARE_MODELS_FOLDER).getPath();
             apeProperties.setProperty(APEProperties.P_APE_MODELS,
                     apeProperties.getProperty(APEProperties.P_APE_MODELS, "") + ";" + projectDirSearchPath);
@@ -300,7 +300,7 @@ public class APE {
             // If the path is relative it will be resolved against the CWD
             // otherwise the absolute path is returned
             resolvedPaths
-                    .append(ResourceRegistry.resolveRelativeFilePath(new File(".").getAbsoluteFile(), splitPaths[i]));
+                    .append(ResourceRegistry.getInstance().resolveRelativeFilePath(new File(".").getAbsoluteFile(), splitPaths[i]));
             if (i < (splitPaths.length - 1)) {
                 resolvedPaths.append(";");
             }

--- a/ARE/tools/APE/src/main/java/eu/asterics/ape/packaging/Packager.java
+++ b/ARE/tools/APE/src/main/java/eu/asterics/ape/packaging/Packager.java
@@ -102,9 +102,9 @@ public class Packager {
         this.modelInspector = modelInspector;
         this.projectDir = new File(apeProperties.getProperty(P_APE_PROJECT_DIR));
 
-        buildDir = ResourceRegistry.resolveRelativeFilePath(projectDir,
+        buildDir = ResourceRegistry.getInstance().resolveRelativeFilePath(projectDir,
                 apeProperties.getProperty(APEProperties.P_APE_BUILD_DIR, APEProperties.DEFAULT_BUILD_DIR));
-        buildMergedDir = ResourceRegistry.resolveRelativeFilePath(buildDir, MERGED_FOLDER);
+        buildMergedDir = ResourceRegistry.getInstance().resolveRelativeFilePath(buildDir, MERGED_FOLDER);
 
         Notifier.info("ApeProp[" + APEProperties.P_APE_BUILD_DIR + "]=" + buildDir);
         
@@ -130,7 +130,7 @@ public class Packager {
             throws URISyntaxException, MalformedURLException, IOException, ParseException, ParserConfigurationException,
             SAXException, TransformerException, BundleManagementException, APEConfigurationException {
         //Create path to merged/bin/ARE folder: the target folder for merging all stuff.
-        File buildMergedAREDir = ResourceRegistry.resolveRelativeFilePath(buildMergedDir, BIN_ARE_FOLDER);
+        File buildMergedAREDir = ResourceRegistry.getInstance().resolveRelativeFilePath(buildMergedDir, BIN_ARE_FOLDER);
         if(buildMode.equals(APE_BUILD_MODE.RELEASE) || !buildMergedAREDir.exists()) {
 			Notifier.info("Copying files to " + buildMergedAREDir);
 
@@ -236,8 +236,8 @@ public class Packager {
      * @param buildDir
      */
     public void copyCustomFiles(File buildDir) {
-        File customBinDir = ResourceRegistry.resolveRelativeFilePath(projectDir, CUSTOM_BIN_FOLDER);
-        File buildMergedBinDir = ResourceRegistry.resolveRelativeFilePath(buildMergedDir, BIN_FOLDER);
+        File customBinDir = ResourceRegistry.getInstance().resolveRelativeFilePath(projectDir, CUSTOM_BIN_FOLDER);
+        File buildMergedBinDir = ResourceRegistry.getInstance().resolveRelativeFilePath(buildMergedDir, BIN_FOLDER);
         try {
             Notifier.info("Copying custom files from <" + customBinDir + "> to <" + buildMergedBinDir + ">");
             FileUtils.copyDirectory(customBinDir, buildMergedBinDir);
@@ -261,7 +261,7 @@ public class Packager {
         // starting with services (excluding config.ini and other files)
         // 2) if no files were found there, use the services files of the
         // ARE.baseURI
-        File servicesFileDir = ResourceRegistry.resolveRelativeFilePath(projectDir,
+        File servicesFileDir = ResourceRegistry.getInstance().resolveRelativeFilePath(projectDir,
                 CUSTOM_BIN_ARE_FOLDER + ResourceRegistry.PROFILE_FOLDER);
 
         FilenameFilter servicesFilesFilter = new FilenameFilter() {
@@ -276,7 +276,7 @@ public class Packager {
         Collection<URI> servicesFilesURIs = ComponentUtils.findFiles(servicesFileDir.toURI(), false, 1,
                 servicesFilesFilter);
 
-        URI areBaseURIProfileFolder = ResourceRegistry.resolveRelativeFilePath(
+        URI areBaseURIProfileFolder = ResourceRegistry.getInstance().resolveRelativeFilePath(
                 ResourceRegistry.getInstance().getAREBaseURI(), ResourceRegistry.PROFILE_FOLDER).toURI();
         String message = "Using services files in " + areBaseURIProfileFolder;
         if (servicesFilesURIs.size() == 0) {
@@ -322,14 +322,14 @@ public class Packager {
      * @param targetSubDir
      */
     public void copyModels(Set<URI> modelURIs, File targetSubDir) {
-        URI customURI = ResourceRegistry.resolveRelativeFilePath(projectDir, CUSTOM_BIN_ARE_MODELS_FOLDER).toURI();
+        URI customURI = ResourceRegistry.getInstance().resolveRelativeFilePath(projectDir, CUSTOM_BIN_ARE_MODELS_FOLDER).toURI();
         for (URI modelURI : modelURIs) {
             // Check if it is a model URI based on ARE base URI, if not copy
             // file directly
             try {
                 // Don't resolve against ARE.baseURI because we just wanna copy
                 // the model files to the bin/ARE/models dir.
-                if (ResourceRegistry.isSubURI(customURI, modelURI)) {
+                if (ResourceRegistry.getInstance().isSubURI(customURI, modelURI)) {
                     Notifier.debug(
                             "Don't copy custom model in copyModels, will be copied in copyCustomFiles: " + modelURI,
                             null);
@@ -372,7 +372,7 @@ public class Packager {
             throws URISyntaxException, IOException {
         try {
             File targetSubDir = targetDir;
-            File src = ResourceRegistry.toFile(srcURI);
+            File src = ResourceRegistry.getInstance().toFile(srcURI);
 
             // If we should resolve against ARE subfolders
             if (resolveAREBaseURISubDirs) {
@@ -380,14 +380,14 @@ public class Packager {
                 // ARE.baseURI.
                 // Determine relative src dir which will then be resolved
                 // against the base target dir.
-                File relativeSrc = ResourceRegistry.toFile(ResourceRegistry.getInstance().toRelative(srcURI));
+                File relativeSrc = ResourceRegistry.getInstance().toFile(ResourceRegistry.getInstance().toRelative(srcURI));
 
                 // Determine parent folder of relativeSrc File
                 targetSubDir = src.isDirectory() ? relativeSrc : relativeSrc.getParentFile();
 
                 if (targetSubDir != null) {
                     // Resolve targetSubDir against targetDir
-                    targetSubDir = ResourceRegistry.resolveRelativeFilePath(targetDir, targetSubDir.getPath());
+                    targetSubDir = ResourceRegistry.getInstance().resolveRelativeFilePath(targetDir, targetSubDir.getPath());
                 } else {
                     targetSubDir = targetDir;
                 }

--- a/ARE/tools/APE/src/main/java/eu/asterics/ape/parse/ModelInspector.java
+++ b/ARE/tools/APE/src/main/java/eu/asterics/ape/parse/ModelInspector.java
@@ -322,7 +322,7 @@ public class ModelInspector {
                 continue;
             }
 
-            File testFile = ResourceRegistry.resolveRelativeFilePath(new File(projectDirPath), modelsPropVal);
+            File testFile = ResourceRegistry.getInstance().resolveRelativeFilePath(new File(projectDirPath), modelsPropVal);
             URI testURI = testFile.toURI();
 
             if (!testFile.exists()) {
@@ -332,7 +332,7 @@ public class ModelInspector {
 
             List<URI> URIs = new ArrayList();
             if (testFile.isDirectory()) {
-                URIs = ResourceRegistry.getModelList(testURI, false);
+                URIs = ResourceRegistry.getInstance().getModelList(testURI, false);
             } else {
                 URIs.add(testURI);
             }
@@ -402,7 +402,7 @@ public class ModelInspector {
                                 // for all types of URIs,
                                 // also URLs, but actually we only wanna copy
                                 // local files.
-                                File propValFile = ResourceRegistry.toFile(propValURI);
+                                File propValFile = ResourceRegistry.getInstance().toFile(propValURI);
 
                                 if (propValFile.exists()) {
                                     // Ok, got it, File exists so we can copy it


### PR DESCRIPTION
Refactored all external (public) static methods to instance methods to ensure flexibility. With static methods it would not be possible to exchange the implementation of the class ResourceRegistry by an overridden version.

Updated all references in AsapiSupport...and APE classes.
In plugins it was not used so far.