### PR TITLE
Fixed compile error of FS20 test class

### DIFF
--- a/ARE/components/actuator.fs20sender/src/test/java/eu/asterics/component/actuator/fS20Sender/PCSDeviceIntegrationTester.java
+++ b/ARE/components/actuator.fs20sender/src/test/java/eu/asterics/component/actuator/fS20Sender/PCSDeviceIntegrationTester.java
@@ -1,10 +1,14 @@
 package eu.asterics.component.actuator.fS20Sender;
 
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 public class PCSDeviceIntegrationTester {
 
     private static PCSDevice device;
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException, ExecutionException, TimeoutException, IOException {
         setup();
         for(int i=0; i<100; i++) {
             device.send(1111, 1111, 28);
@@ -22,7 +26,7 @@ public class PCSDeviceIntegrationTester {
         device.close();
     }
 
-    private static void setup() {
+    private static void setup() throws InterruptedException, ExecutionException, TimeoutException, IOException {
         device = new PCSDevice();
         device.open();
     }


### PR DESCRIPTION
added throwing of exception of device.close and device.open.
This class is actually not a junit test case but at least it is compilable now and hence not shown in the Eclipse error report.