### PR TITLE
Klaus/issue#269/f8 opens explorer

### DIFF
--- a/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
@@ -192,7 +192,7 @@ public class OSUtils {
 
             Matcher m = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(arguments);
             while (m.find()) {
-                String token = m.group(1);
+                String token = m.group(1).replace("\"", "");
                 command.add(token);
                 logger.fine("adding argument: " + token);
             }

--- a/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
@@ -190,7 +190,15 @@ public class OSUtils {
                 logger.fine("No cmd arguments found.");
             }
 
-            Matcher m = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(arguments);
+            //regex: (([^\s"]+)|(".+?"))\s*
+            //splits arguments with or without quotes, see http://www.regexe.com/ for testing
+            //e.g. xterm -e "sudo sh test.sh" ==> (1) xterm, (2) -e, (3) "sudo sh test.sh"
+            //pattern: (A|B)C => A or B, afterwards C
+            //A = ([^\s"]+)     ==> matches anything that does not contain quotes and
+            //                      does only contain non-whitespace characters ([^\s]), e.g. -e
+            //B = (".+?")       ==> matches anything enquoted with any characters inside, e.g. "sudo sh test.sh"
+            //C = \s*           ==> any whitespace character(s) after each group
+            Matcher m = Pattern.compile("(([^\\s\"]+)|(\".+?\"))\\s*").matcher(arguments);
             while (m.find()) {
                 String token = m.group(1).replace("\"", "");
                 command.add(token);

--- a/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
@@ -235,13 +235,17 @@ public class OSUtils {
     public static Process openURL(String urlToOpen, OS_NAMES executeOnPlatform) throws IOException {
         if (executeOnPlatform != null && getOsName().equalsIgnoreCase(executeOnPlatform.toString()) || executeOnPlatform.equals(OS_NAMES.ALL)) {
             String browserStartCmd = AREProperties.instance.getProperty(ARE_OPEN_URL_CMD_KEY_PREFIX + getOsName());
-            
-            
-            String urlToOpenQuoted = urlToOpen;
+
+            urlToOpen = urlToOpen.trim();
+            urlToOpen = urlToOpen.replaceAll("^\"|\"$", ""); // remove quotes
+            if(!urlToOpen.startsWith("http")) {
+                urlToOpen = "http://" + urlToOpen;
+            }
             if(isWindows()) {
-				urlToOpenQuoted="\"" + urlToOpen + "\"";
+                urlToOpen="\"" + urlToOpen + "\"";
 			}
-            return startApplication(browserStartCmd, urlToOpenQuoted, null, executeOnPlatform);
+
+            return startApplication(browserStartCmd, urlToOpen, null, executeOnPlatform);
         }
         return null;
     }

--- a/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
@@ -195,7 +195,7 @@ public class OSUtils {
 
                 Matcher m = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(arguments);
                 while (m.find()) {
-                    String token = m.group(1).replace("\"", "");
+                    String token = m.group(1);
                     command.add(token);
                     logger.fine("adding argument: " + token);
                 }

--- a/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
@@ -134,7 +134,7 @@ public class OSUtils {
             return null;
         }
         // quote command if it is with spaces
-        if(applicationPath.contains(" ")) {
+        if(applicationPath.contains(" ") && !applicationPath.startsWith("\"")) {
 			applicationPath = "\"" + applicationPath + "\"";
         }
         // File applicationPathFile = ResourceRegistry.resolveRelativeFilePath(ResourceRegistry.getInstance().getAREBaseURI(), applicationPath);

--- a/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/utils/OSUtils.java
@@ -53,7 +53,7 @@ public class OSUtils {
     public static final String ARE_OPEN_URL_CMD_KEY_PREFIX = "ARE.openURL.cmd.";
 
     static {
-        AREProperties.instance.setDefaultPropertyValue(ARE_OPEN_URL_CMD_KEY_PREFIX + LINUX, "sensible-browser", "Default Linux command to start a browser.");
+        AREProperties.instance.setDefaultPropertyValue(ARE_OPEN_URL_CMD_KEY_PREFIX + LINUX, "xdg-open", "Default Linux command to start a browser.");
         AREProperties.instance.setDefaultPropertyValue(ARE_OPEN_URL_CMD_KEY_PREFIX + WINDOWS, "explorer", "Default Windows command to start a browser.");
         AREProperties.instance.setDefaultPropertyValue(ARE_OPEN_URL_CMD_KEY_PREFIX + MACOSX, "open", "Default Mac OSX command to start a browser.");
     }

--- a/Documentation/ACS-Help/HTML/Plugins/actuators/ApplicationLauncher.htm
+++ b/Documentation/ACS-Help/HTML/Plugins/actuators/ApplicationLauncher.htm
@@ -49,7 +49,8 @@
 				<STRONG>arguments [string]:</STRONG> the commandline arguments for the application (in mode START_APPLICATION) or the URL to open (in mode OPEN_URL).<br/>
 				For Mode START_APPLICATION: Given arguments are split considering whitespaces and quotes. So e.g. the arguments property <i>xterm -e "sudo sh test.sh"</i> will be split in 3 components
 				<i>xterm</i>, <i>-e</i> and <i>"sudo sh test.sh"</i>. However quotes are removed at runtime, so <i>sudo sh test.sh</i> without quotes will be passed to the ProcessBuilder used at Java level to start the program.<br/>
-				Hint for Windows: for cmd.exe "&" is a special character and cannot be used in an argument. If the "&" is needed, mask it with an "^", therefore using "^&" instead of "&" in the argument.
+				Hint for Windows: for cmd.exe "&" is a special character and cannot be used in an argument. If the "&" is needed, mask it with an "^", therefore using "^&" instead of "&" in the argument.<br/>
+				For Mode OPEN_URL: URLs can be passed as-is on any platform, no masking of "&" characters is needed.
 			</li>
 			<li><STRONG>workingDirectory [string]:</STRONG> the working directory for the application (. is used for home directory of the application)</li>
 			<li><STRONG>closeCmd [string]:</STRONG>Optional close cmd, e.g. if started cmd has forked processes (e.g. OSKA) use: taskkill.exe /IM &quot;OSKA Keyboard.exe&quot; /T</li>

--- a/Documentation/ACS-Help/HTML/Plugins/actuators/ApplicationLauncher.htm
+++ b/Documentation/ACS-Help/HTML/Plugins/actuators/ApplicationLauncher.htm
@@ -40,7 +40,7 @@
 		<H2>Properties</H2>
 		<ul>
 			<li><STRONG>executeOnPlatform [combobox (ALL, WINDOWS, LINUX, MACOSX)]:</STRONG> If != ALL, the application will only be launched if the ARE runs on the defined platform.</li>
-			<li><STRONG>executionMode [combobox (START_APPLICATION, OPEN_URL)]:</STRONG> If START_APPLICATION, the command defined in defaultApplication will be launched with the given arguments. If OPEN_URL, the URL defined in arguments will be launched with the platform default browser. The platform-specific browser launch commands are configurable in the file areProperties.</li>
+			<li><STRONG>executionMode [combobox (START_APPLICATION, OPEN_URL)]:</STRONG> If START_APPLICATION, the command defined in defaultApplication will be launched with the given arguments. If OPEN_URL, the URL defined in arguments will be launched with the platform default browser. The platform-specific browser launch commands are configurable in the file areProperties. For general information about platform-specific launch commands, see <a href="https://dwheeler.com/essays/open-files-urls.html">open files and URLs</a></li>
 			<li>
 				<STRONG>defaultApplication [string]:</STRONG> Full path and filename of the default application<br/>
 				The full path can be provided with quotes, but quotes are not mandatory. So <i>C:\Program Files\internet explorer\iexplore.exe</i> and <i>"C:\Program Files\internet explorer\iexplore.exe"</i> are equal and both working.

--- a/Documentation/ACS-Help/HTML/Plugins/actuators/ApplicationLauncher.htm
+++ b/Documentation/ACS-Help/HTML/Plugins/actuators/ApplicationLauncher.htm
@@ -16,8 +16,8 @@
 		</figure>
 		<H2>Input Port Description</H2>
 		<ul>
-			<li><STRONG>filename [string]:</STRONG> File name of executable file which shall be started without arguments. The application is started automatically, if onlyByEvent is false.</li>
-			<li><STRONG>arguments [string]:</STRONG> Sets the arguments of the command. The application is started automatically, if onlyByEvent is false.</li>
+			<li><STRONG>filename [string]:</STRONG> File name of executable file which shall be started without arguments. The application is started automatically, if onlyByEvent is false. See <i>Propterties -> defaultApplication</i> description for details.</li>
+			<li><STRONG>arguments [string]:</STRONG> Sets the arguments of the command. The application is started automatically, if onlyByEvent is false. See <i>Propterties -> arguments</i> description for details.</li>
 			<li><STRONG>stdIn [string]:</STRONG> Sends the incoming string to the standard input stream of the started process.</li>
 		</ul>
 		<H2>Output Port Description</H2>
@@ -41,8 +41,16 @@
 		<ul>
 			<li><STRONG>executeOnPlatform [combobox (ALL, WINDOWS, LINUX, MACOSX)]:</STRONG> If != ALL, the application will only be launched if the ARE runs on the defined platform.</li>
 			<li><STRONG>executionMode [combobox (START_APPLICATION, OPEN_URL)]:</STRONG> If START_APPLICATION, the command defined in defaultApplication will be launched with the given arguments. If OPEN_URL, the URL defined in arguments will be launched with the platform default browser. The platform-specific browser launch commands are configurable in the file areProperties.</li>
-			<li><STRONG>defaultApplication [string]:</STRONG> Full path and filename of the default application</li>
-			<li><STRONG>arguments [string]:</STRONG> the commandline arguments for the application</li>
+			<li>
+				<STRONG>defaultApplication [string]:</STRONG> Full path and filename of the default application<br/>
+				The full path can be provided with quotes, but quotes are not mandatory. So <i>C:\Program Files\internet explorer\iexplore.exe</i> and <i>"C:\Program Files\internet explorer\iexplore.exe"</i> are equal and both working.
+			</li>
+			<li>
+				<STRONG>arguments [string]:</STRONG> the commandline arguments for the application (in mode START_APPLICATION) or the URL to open (in mode OPEN_URL).<br/>
+				For Mode START_APPLICATION: Given arguments are split considering whitespaces and quotes. So e.g. the arguments property <i>xterm -e "sudo sh test.sh"</i> will be split in 3 components
+				<i>xterm</i>, <i>-e</i> and <i>"sudo sh test.sh"</i>. However quotes are removed at runtime, so <i>sudo sh test.sh</i> without quotes will be passed to the ProcessBuilder used at Java level to start the program.<br/>
+				Hint for Windows: for cmd.exe "&" is a special character and cannot be used in an argument. If the "&" is needed, mask it with an "^", therefore using "^&" instead of "&" in the argument.
+			</li>
 			<li><STRONG>workingDirectory [string]:</STRONG> the working directory for the application (. is used for home directory of the application)</li>
 			<li><STRONG>closeCmd [string]:</STRONG>Optional close cmd, e.g. if started cmd has forked processes (e.g. OSKA) use: taskkill.exe /IM &quot;OSKA Keyboard.exe&quot; /T</li>
 			<li><STRONG>autoLaunch [boolean]:</STRONG> Defines if the default application is automatically launched at startup</li>

--- a/Installer/asterics-are/package/linux/control
+++ b/Installer/asterics-are/package/linux/control
@@ -8,4 +8,4 @@ Homepage: https://github.com/asterics/AsTeRICS
 Provides: asterics-are
 Description: AsTeRICS Runtime Environment (ARE) - http://www.asterics.org
 Recommends: oracle-java8-installer
-Depends: libttspico-utils, libhidapi-libusb0, libudev1
+Depends: libttspico-utils, libhidapi-libusb0, libudev1, xdg-utils


### PR DESCRIPTION
My solution for #269 although I'm not sure if it is perfect.
It resolves the main problem -> `F8` now again opens WebACS (tested on Windows and Linux)

But the general problem in the ApplicationLauncher plugin was: sometimes we need quotes on arguments, sometimes not. More exactly:
1) OPEN_URL mode with argument like `"http://www.google.com/search?source=hp&btnK=Google-Suche&q=test"` needs the quotes on windows because otherwise the special cmd-char `&` breaks the command
2) START_APPLICATION mode with e.g. application `xterm` and arguments `-e "sudo sh test.sh"` need to be parsed to the arguments `-e` and `sudo sh test.sh` without quotes on the last part, otherwise it does not work (tested on ubuntu)

Therefore my solution is the following:
1) I introduced a new private method where the array of command+argument can be directly passed. `openURL()` uses it and therefore can pass the URL with qoutes as needed for problem (1)
2) the normal `startApplication()` again removes the qoutes so that problem case (2) works correclty.

I've tested several scenarios on Mac, Windows and Linux:
1) Open URLs like `www.google.com/search?source=hp&btnK=Google-Suche&q=test`, `"www.google.com/search?source=hp&btnK=Google-Suche&q=test"`, `google.at` or `"google.at"` --> all of this works!
2) Start commands like `xterm -e "sudo sh test.sh"`, `ps`, `ps -aux`, `ls /` (on linux) or `dir`, `explorer <path with spaces>` --> all of this works!

So it seems that it should be a good solution.
However it is not possible to use `START_APPLICATION` where a quoted parameter remains quoted in the final string-array. I don't know if this is needed at any point.