### PR TITLE
keep simple if on one line -> true

### DIFF
--- a/ARE/Eclipse - Code Style - Formatter.xml
+++ b/ARE/Eclipse - Code Style - Formatter.xml
@@ -235,7 +235,7 @@
 <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>


### PR DESCRIPTION
change in the formatter file which has this effect:
(1) before:
```
if (object == null)
        return; 
```
(2) afterwards:
`if (object == null) return; `

I like style (2) much more. To my mind every if clause that has more than 1 line should have curly brackets, see e.g. https://www.imperialviolet.org/2014/02/22/applebug.html