### PR TITLE
added property CIM.scan.at.start

### DIFF
--- a/ARE/services/CIMCommunication/src/main/java/eu/asterics/mw/cimcommunication/CIMCommunicationBundleActivator.java
+++ b/ARE/services/CIMCommunication/src/main/java/eu/asterics/mw/cimcommunication/CIMCommunicationBundleActivator.java
@@ -28,12 +28,20 @@ package eu.asterics.mw.cimcommunication;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
+import eu.asterics.mw.are.AREProperties;
+
 public class CIMCommunicationBundleActivator implements BundleActivator {
 
+    private final String PROPERTY_CIMSCAN_AT_START = "CIM.scan.at.start";
+    
     @Override
     public void start(BundleContext arg0) throws Exception {
         System.out.println("cim start");
-        CIMPortManager.getInstance().rescan();
+        AREProperties.instance.setDefaultPropertyValue(PROPERTY_CIMSCAN_AT_START, "true", "If true the CIM port scanning is performed at start of ARE");
+        boolean doScan = Boolean.valueOf(AREProperties.instance.getProperty(PROPERTY_CIMSCAN_AT_START));
+        if (doScan) {
+            CIMPortManager.getInstance().rescan();
+        }
     }
 
     @Override


### PR DESCRIPTION
added property `CIM.scan.at.start=true` to ARE properties.
makes it possible to disable automatic CIM port scanning at start of ARE.

for my tests with EMG the EMG sensors CIM port scanning always slowed down restart of ARE and possibility to use SerialPort, so I've added this property to disable automatic CIM port scanning.
Also for solutions e.g. like for C.B. CIM port scanning could/should be disabled, because it is simply not needed for his solution.