### PR TITLE
fixed delimiter for knx commands, should not contain space " " since …

### DIFF
--- a/ARE/components/actuator.knx/src/main/java/eu/asterics/component/actuator/knx/KnxInstance.java
+++ b/ARE/components/actuator.knx/src/main/java/eu/asterics/component/actuator/knx/KnxInstance.java
@@ -691,8 +691,8 @@ public class KnxInstance extends AbstractRuntimeComponentInstance {
 
             if (text.startsWith("@KNX:")) {
                 try {
-                    StringTokenizer st = new StringTokenizer(text.substring(5), " ,#");
-                    sendKNX(st.nextToken(), st.nextToken(), st.nextToken());
+                    StringTokenizer st = new StringTokenizer(text.substring(5), ",#");
+                    sendKNX(st.nextToken().trim(), st.nextToken().trim(), st.nextToken().trim());
                 } catch (Exception e) {
                     AstericsErrorHandling.instance.getLogger().severe(e.toString());
                 }


### PR DESCRIPTION
…some knx-commands contain spaces

e.g. KNX command `@KNX:0/1/1,3.007,decrease 2` was not possible because `decrease` and `2` were parsed as two tokens, but should be one token.