### PR TITLE
StringFormatter: possibility to revert to default value after sending

### DIFF
--- a/ARE/components/processor.stringformatter/src/main/java/eu/asterics/component/processor/stringformatter/StringFormatterInstance.java
+++ b/ARE/components/processor.stringformatter/src/main/java/eu/asterics/component/processor/stringformatter/StringFormatterInstance.java
@@ -25,139 +25,135 @@
 
 package eu.asterics.component.processor.stringformatter;
 
-
 import eu.asterics.mw.data.ConversionUtils;
-import eu.asterics.mw.model.runtime.AbstractRuntimeComponentInstance;
-import eu.asterics.mw.model.runtime.IRuntimeEventListenerPort;
-import eu.asterics.mw.model.runtime.IRuntimeEventTriggererPort;
-import eu.asterics.mw.model.runtime.IRuntimeInputPort;
-import eu.asterics.mw.model.runtime.IRuntimeOutputPort;
+import eu.asterics.mw.model.runtime.*;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeInputPort;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeOutputPort;
 
 /**
- * This plugin provides the functionality of the Java @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html">Formatter class</a>. 
- *  
- * @author Martin Deinhofer [deinhofe@technikum-wien.at]
- *         Date: 20170502 
+ * This plugin provides the functionality of the Java @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html">Formatter class</a>.
+ * 
+ * @author Martin Deinhofer [deinhofe@technikum-wien.at] Date: 20170502
  */
 
-public class StringFormatterInstance extends AbstractRuntimeComponentInstance
-{
-	final IRuntimeOutputPort opFormattedStr = new DefaultRuntimeOutputPort();
-	// Usage of an output port e.g.: opMyOutPort.sendData(ConversionUtils.intToBytes(10)); 
+public class StringFormatterInstance extends AbstractRuntimeComponentInstance {
+    final IRuntimeOutputPort opFormattedStr = new DefaultRuntimeOutputPort();
+    // Usage of an output port e.g.: opMyOutPort.sendData(ConversionUtils.intToBytes(10));
 
-	// Usage of an event trigger port e.g.: etpMyEtPort.raiseEvent();
+    // Usage of an event trigger port e.g.: etpMyEtPort.raiseEvent();
 
-	String propFormatString = "%1$s, %2$s, %3$4.2f, %4$d";
-	boolean propSendOnlyByEvent=false;
-	
-	// declare member variables here
-	Object[] inputVariables=new Object[4];
-	Object[] defaultVariableValues=new Object[4];
-	
+    String propFormatString = "%1$s, %2$s, %3$4.2f, %4$d";
+    Boolean[] propToDefaultAfterSend = { false, false, false, false };
+    boolean propSendOnlyByEvent = false;
 
-    
-   /**
-    * The class constructor.
-    */
-    public StringFormatterInstance()
-    {
+    // declare member variables here
+    Object[] inputVariables = new Object[4];
+    Object[] defaultVariableValues = new Object[4];
+
+    /**
+     * The class constructor.
+     */
+    public StringFormatterInstance() {
         // empty constructor
     }
 
-   /**
-    * returns an Input Port.
-    * @param portID   the name of the port
-    * @return         the input port or null if not found
-    */
-    public IRuntimeInputPort getInputPort(String portID)
-    {
-		if ("in1String".equalsIgnoreCase(portID))
-		{
-			return ipIn1String;
-		}
-		if ("in2String".equalsIgnoreCase(portID))
-		{
-			return ipIn2String;
-		}
-		if ("in3Double".equalsIgnoreCase(portID))
-		{
-			return ipIn3Double;
-		}
-		if ("in4Integer".equalsIgnoreCase(portID))
-		{
-			return ipIn4Integer;
-		}
-		if ("setFormatStr".equalsIgnoreCase(portID))
-		{
-			return ipSetFormatStr;
-		}
+    /**
+     * returns an Input Port.
+     * 
+     * @param portID
+     *            the name of the port
+     * @return the input port or null if not found
+     */
+    public IRuntimeInputPort getInputPort(String portID) {
+        if ("in1String".equalsIgnoreCase(portID)) {
+            return ipIn1String;
+        }
+        if ("in2String".equalsIgnoreCase(portID)) {
+            return ipIn2String;
+        }
+        if ("in3Double".equalsIgnoreCase(portID)) {
+            return ipIn3Double;
+        }
+        if ("in4Integer".equalsIgnoreCase(portID)) {
+            return ipIn4Integer;
+        }
+        if ("setFormatStr".equalsIgnoreCase(portID)) {
+            return ipSetFormatStr;
+        }
 
-		return null;
-	}
+        return null;
+    }
 
     /**
      * returns an Output Port.
-     * @param portID   the name of the port
-     * @return         the output port or null if not found
+     * 
+     * @param portID
+     *            the name of the port
+     * @return the output port or null if not found
      */
-    public IRuntimeOutputPort getOutputPort(String portID)
-	{
-		if ("formattedStr".equalsIgnoreCase(portID))
-		{
-			return opFormattedStr;
-		}
+    public IRuntimeOutputPort getOutputPort(String portID) {
+        if ("formattedStr".equalsIgnoreCase(portID)) {
+            return opFormattedStr;
+        }
 
-		return null;
-	}
+        return null;
+    }
 
     /**
      * returns an Event Listener Port.
-     * @param eventPortID   the name of the port
-     * @return         the EventListener port or null if not found
+     * 
+     * @param eventPortID
+     *            the name of the port
+     * @return the EventListener port or null if not found
      */
-    public IRuntimeEventListenerPort getEventListenerPort(String eventPortID)
-    {
-		if ("sendFormattedStr".equalsIgnoreCase(eventPortID))
-		{
-			return elpSendFormattedStr;
-		}
+    public IRuntimeEventListenerPort getEventListenerPort(String eventPortID) {
+        if ("sendFormattedStr".equalsIgnoreCase(eventPortID)) {
+            return elpSendFormattedStr;
+        }
 
         return null;
     }
 
     /**
      * returns an Event Triggerer Port.
-     * @param eventPortID   the name of the port
-     * @return         the EventTriggerer port or null if not found
+     * 
+     * @param eventPortID
+     *            the name of the port
+     * @return the EventTriggerer port or null if not found
      */
-    public IRuntimeEventTriggererPort getEventTriggererPort(String eventPortID)
-    {
+    public IRuntimeEventTriggererPort getEventTriggererPort(String eventPortID) {
 
         return null;
     }
-		
+
     /**
      * returns the value of the given property.
-     * @param propertyName   the name of the property
-     * @return               the property value or null if not found
+     * 
+     * @param propertyName
+     *            the name of the property
+     * @return the property value or null if not found
      */
-    public Object getRuntimePropertyValue(String propertyName)
-    {
-		if ("formatString".equalsIgnoreCase(propertyName))
-		{
-			return propFormatString;
-		} else if("defaultIn1String".equalsIgnoreCase(propertyName)) {
-		    return defaultVariableValues[0];
-		} else if("defaultIn2String".equalsIgnoreCase(propertyName)) {
+    public Object getRuntimePropertyValue(String propertyName) {
+        if ("formatString".equalsIgnoreCase(propertyName)) {
+            return propFormatString;
+        } else if ("defaultIn1String".equalsIgnoreCase(propertyName)) {
+            return defaultVariableValues[0];
+        } else if ("defaultIn2String".equalsIgnoreCase(propertyName)) {
             return defaultVariableValues[1];
-        } else if("defaultIn3Double".equalsIgnoreCase(propertyName)) {
+        } else if ("defaultIn3Double".equalsIgnoreCase(propertyName)) {
             return defaultVariableValues[2];
-        } else if("defaultIn4Integer".equalsIgnoreCase(propertyName)) {
+        } else if ("defaultIn4Integer".equalsIgnoreCase(propertyName)) {
             return defaultVariableValues[3];
-        } else if("sendOnlyByEvent".equalsIgnoreCase(propertyName)) {
+        } else if ("sendOnlyByEvent".equalsIgnoreCase(propertyName)) {
             return propSendOnlyByEvent;
+        } else if ("port1ToDefaultAfterSend".equalsIgnoreCase(propertyName)) {
+            return propToDefaultAfterSend[0];
+        } else if ("port2ToDefaultAfterSend".equalsIgnoreCase(propertyName)) {
+            return propToDefaultAfterSend[1];
+        } else if ("port3ToDefaultAfterSend".equalsIgnoreCase(propertyName)) {
+            return propToDefaultAfterSend[2];
+        } else if ("port4ToDefaultAfterSend".equalsIgnoreCase(propertyName)) {
+            return propToDefaultAfterSend[3];
         }
 
         return null;
@@ -165,186 +161,173 @@ public class StringFormatterInstance extends AbstractRuntimeComponentInstance
 
     /**
      * sets a new value for the given property.
-     * @param propertyName   the name of the property
-     * @param newValue       the desired property value or null if not found
+     * 
+     * @param propertyName
+     *            the name of the property
+     * @param newValue
+     *            the desired property value or null if not found
      */
-    public Object setRuntimePropertyValue(String propertyName, Object newValue)
-    {
-		if ("formatString".equalsIgnoreCase(propertyName))
-		{
-			final Object oldValue = propFormatString;
-			propFormatString = (String)newValue;
-			return oldValue;
-		} else if("defaultIn1String".equalsIgnoreCase(propertyName)) {
-		    if(newValue!=null) {
-	            final Object oldValue = defaultVariableValues[0];
-	            defaultVariableValues[0] = (String)newValue;
-	            return oldValue;		        
-		    }
-		} else if("defaultIn2String".equalsIgnoreCase(propertyName)) {
-            if(newValue!=null) {
-                final Object oldValue = defaultVariableValues[1];
-                defaultVariableValues[1] = (String)newValue;
-                return oldValue;                
+    public Object setRuntimePropertyValue(String propertyName, Object newValue) {
+        if ("formatString".equalsIgnoreCase(propertyName)) {
+            final Object oldValue = propFormatString;
+            propFormatString = (String) newValue;
+            return oldValue;
+        } else if ("defaultIn1String".equalsIgnoreCase(propertyName)) {
+            if (newValue != null) {
+                final Object oldValue = defaultVariableValues[0];
+                defaultVariableValues[0] = (String) newValue;
+                return oldValue;
             }
-        } else if("defaultIn3Double".equalsIgnoreCase(propertyName)) {
-            if(newValue!=null) {
+        } else if ("defaultIn2String".equalsIgnoreCase(propertyName)) {
+            if (newValue != null) {
+                final Object oldValue = defaultVariableValues[1];
+                defaultVariableValues[1] = (String) newValue;
+                return oldValue;
+            }
+        } else if ("defaultIn3Double".equalsIgnoreCase(propertyName)) {
+            if (newValue != null) {
                 final Object oldValue = defaultVariableValues[2];
                 defaultVariableValues[2] = Double.parseDouble((String) newValue);
-                return oldValue;                
+                return oldValue;
             }
-        } else if("defaultIn4Integer".equalsIgnoreCase(propertyName)) {
-            if(newValue!=null) {
+        } else if ("defaultIn4Integer".equalsIgnoreCase(propertyName)) {
+            if (newValue != null) {
                 final Object oldValue = defaultVariableValues[3];
-                defaultVariableValues[3] = Integer.parseInt((String)newValue);
-                return oldValue;                
+                defaultVariableValues[3] = Integer.parseInt((String) newValue);
+                return oldValue;
             }
-        } else if("sendOnlyByEvent".equalsIgnoreCase(propertyName)) {
+        } else if ("sendOnlyByEvent".equalsIgnoreCase(propertyName)) {
             final Object oldValue = propSendOnlyByEvent;
-            propSendOnlyByEvent = Boolean.parseBoolean((String)newValue);
+            propSendOnlyByEvent = Boolean.parseBoolean((String) newValue);
+            return oldValue;
+        } else if ("port1ToDefaultAfterSend".equalsIgnoreCase(propertyName)) {
+            final Object oldValue = propToDefaultAfterSend[0];
+            propToDefaultAfterSend[0] = Boolean.parseBoolean((String) newValue);
+            return oldValue;
+        } else if ("port2ToDefaultAfterSend".equalsIgnoreCase(propertyName)) {
+            final Object oldValue = propToDefaultAfterSend[1];
+            propToDefaultAfterSend[1] = Boolean.parseBoolean((String) newValue);
+            return oldValue;
+        } else if ("port3ToDefaultAfterSend".equalsIgnoreCase(propertyName)) {
+            final Object oldValue = propToDefaultAfterSend[2];
+            propToDefaultAfterSend[2] = Boolean.parseBoolean((String) newValue);
+            return oldValue;
+        } else if ("port4ToDefaultAfterSend".equalsIgnoreCase(propertyName)) {
+            final Object oldValue = propToDefaultAfterSend[3];
+            propToDefaultAfterSend[3] = Boolean.parseBoolean((String) newValue);
             return oldValue;
         }
 
         return null;
     }
 
-     /**
-      * Input Ports for receiving values.
-      */
-	private final IRuntimeInputPort ipIn1String  = new DefaultRuntimeInputPort()
-	{
-		public void receiveData(byte[] data)
-		{
-				 // insert data reception handling here, e.g.: 
-				 // myVar = ConversionUtils.doubleFromBytes(data); 
-				 // myVar = ConversionUtils.stringFromBytes(data); 
-				 // myVar = ConversionUtils.intFromBytes(data);
-		    inputVariables[0]=ConversionUtils.stringFromBytes(data);
-		    formatAndSendString(false);
-		}
-	};
-	private final IRuntimeInputPort ipIn2String  = new DefaultRuntimeInputPort()
-	{
-		public void receiveData(byte[] data)
-		{
-				 // insert data reception handling here, e.g.: 
-				 // myVar = ConversionUtils.doubleFromBytes(data); 
-				 // myVar = ConversionUtils.stringFromBytes(data); 
-				 // myVar = ConversionUtils.intFromBytes(data); 
-		    inputVariables[1]=ConversionUtils.stringFromBytes(data);
-		    formatAndSendString(false);
-		}
-	};
-	private final IRuntimeInputPort ipIn3Double  = new DefaultRuntimeInputPort()
-	{
-		public void receiveData(byte[] data)
-		{
-				 // insert data reception handling here, e.g.: 
-				 // myVar = ConversionUtils.doubleFromBytes(data); 
-				 // myVar = ConversionUtils.stringFromBytes(data); 
-				 // myVar = ConversionUtils.intFromBytes(data);
-		    inputVariables[2]=ConversionUtils.doubleFromBytes(data);
-		    formatAndSendString(false);
-		}
-	};
-	private final IRuntimeInputPort ipIn4Integer  = new DefaultRuntimeInputPort()
-	{
-		public void receiveData(byte[] data)
-		{
-				 // insert data reception handling here, e.g.: 
-				 // myVar = ConversionUtils.doubleFromBytes(data); 
-				 // myVar = ConversionUtils.stringFromBytes(data); 
-				 // myVar = ConversionUtils.intFromBytes(data); 
-		    inputVariables[3]=ConversionUtils.intFromBytes(data);
-		    formatAndSendString(false);
-		}
-	};
-	private final IRuntimeInputPort ipSetFormatStr  = new DefaultRuntimeInputPort()
-	{
-		public void receiveData(byte[] data)
-		{
-				 // insert data reception handling here, e.g.: 
-				 // myVar = ConversionUtils.doubleFromBytes(data); 
-				 // myVar = ConversionUtils.stringFromBytes(data); 
-				 // myVar = ConversionUtils.intFromBytes(data);
-		    setRuntimePropertyValue("formatString", ConversionUtils.stringFromBytes(data));
-		}
-	};
+    /**
+     * Input Ports for receiving values.
+     */
+    private final IRuntimeInputPort ipIn1String = new DefaultRuntimeInputPort() {
+        public void receiveData(byte[] data) {
+            inputVariables[0] = ConversionUtils.stringFromBytes(data);
+            processPortInput(0);
+        }
+    };
+    private final IRuntimeInputPort ipIn2String = new DefaultRuntimeInputPort() {
+        public void receiveData(byte[] data) {
+            inputVariables[1] = ConversionUtils.stringFromBytes(data);
+            processPortInput(1);
+        }
+    };
+    private final IRuntimeInputPort ipIn3Double = new DefaultRuntimeInputPort() {
+        public void receiveData(byte[] data) {
+            inputVariables[2] = ConversionUtils.doubleFromBytes(data);
+            processPortInput(2);
+        }
+    };
+    private final IRuntimeInputPort ipIn4Integer = new DefaultRuntimeInputPort() {
+        public void receiveData(byte[] data) {
+            inputVariables[3] = ConversionUtils.intFromBytes(data);
+            processPortInput(3);
+        }
+    };
+    private final IRuntimeInputPort ipSetFormatStr = new DefaultRuntimeInputPort() {
+        public void receiveData(byte[] data) {
+            setRuntimePropertyValue("formatString", ConversionUtils.stringFromBytes(data));
+        }
+    };
 
+    private void processPortInput(int nr) {
+        formatAndSendString(false);
+        if (propToDefaultAfterSend[nr]) {
+            inputVariables[nr] = defaultVariableValues[nr];
+        }
+    }
 
-     /**
-      * Event Listerner Ports.
-      */
-	final IRuntimeEventListenerPort elpSendFormattedStr = new IRuntimeEventListenerPort()
-	{
-		public void receiveEvent(final String data)
-		{
-				 // insert event handling here
-		    formatAndSendString(true);
-		}
-	};
+    /**
+     * Event Listerner Ports.
+     */
+    final IRuntimeEventListenerPort elpSendFormattedStr = new IRuntimeEventListenerPort() {
+        public void receiveEvent(final String data) {
+            // insert event handling here
+            formatAndSendString(true);
+        }
+    };
 
-	
+    /**
+     * called when model is started.
+     */
+    @Override
+    public void start() {
+        super.start();
+    }
 
-     /**
-      * called when model is started.
-      */
-      @Override
-      public void start()
-      {   
-          super.start();
-      }
+    /**
+     * called when model is paused.
+     */
+    @Override
+    public void pause() {
+        super.pause();
+    }
 
-     /**
-      * called when model is paused.
-      */
-      @Override
-      public void pause()
-      {
-          super.pause();
-      }
+    /**
+     * called when model is resumed.
+     */
+    @Override
+    public void resume() {
+        super.resume();
+    }
 
-     /**
-      * called when model is resumed.
-      */
-      @Override
-      public void resume()
-      {
-          super.resume();
-      }
+    /**
+     * called when model is stopped.
+     */
+    @Override
+    public void stop() {
 
-     /**
-      * called when model is stopped.
-      */
-      @Override
-      public void stop()
-      {
+        super.stop();
+    }
 
-          super.stop();
-      }
-            
-      /**
-       * Formats and sends the resulting foramtted string to the output port.
-     * @param triggeredByEvent TODO
-       */
-      private void formatAndSendString(boolean triggeredByEvent) {
-          if(propSendOnlyByEvent && !triggeredByEvent) {
-              return;
-          }
-          
-          //get current format string
-          String curFormatString=(String)getRuntimePropertyValue("formatString");
-       
-          //override input variables with defaults, if the value on the input port is null.
-          for(int i=0;i<inputVariables.length;i++) {
-              if(inputVariables[i]==null) {                  
-                  inputVariables[i]=defaultVariableValues[i];
-              }
-          }
+    /**
+     * Formats and sends the resulting foramtted string to the output port.
+     * 
+     * @param triggeredByEvent
+     *            TODO
+     */
+    private void formatAndSendString(boolean triggeredByEvent) {
+        if (propSendOnlyByEvent && !triggeredByEvent) {
+            return;
+        }
+
+        // get current format string
+        String curFormatString = (String) getRuntimePropertyValue("formatString");
+
+        // override input variables with defaults, if the value on the input port is null.
+        for (int i = 0; i < inputVariables.length; i++) {
+            if (inputVariables[i] == null) {
+                inputVariables[i] = defaultVariableValues[i];
+            }
+        }
 
         // Execute actual formatting of string
         String formattedString = String.format(curFormatString, inputVariables);
         // Convert formatted string to byte[] and send it to the output port
         opFormattedStr.sendData(ConversionUtils.stringToBytes(formattedString));
-      }
+    }
 }

--- a/ARE/components/processor.stringformatter/src/main/resources/bundle_descriptor.xml
+++ b/ARE/components/processor.stringformatter/src/main/resources/bundle_descriptor.xml
@@ -67,11 +67,27 @@
 			<property name="defaultIn4Integer"
 				type="integer"
 				value="0"
-				description="The default value of in4Integer. Used if there is no input port value."/>				
+				description="The default value of in4Integer. Used if there is no input port value."/>
 			<property name="sendOnlyByEvent"
 				type="boolean"
-				value="0"
-				description="Only sends the value of the formatted string, if the event sendFormattedStr is received."/>				
+				value="false"
+				description="Only sends the value of the formatted string, if the event sendFormattedStr is received."/>
+			<property name="port1ToDefaultAfterSend"
+					type="boolean"
+					value="false"
+					description="If true, input port 1 is reverted to default value, after value was sent."/>
+			<property name="port2ToDefaultAfterSend"
+					  type="boolean"
+					  value="false"
+					  description="If true, input port 2 is reverted to default value, after value was sent."/>
+			<property name="port3ToDefaultAfterSend"
+					  type="boolean"
+					  value="false"
+					  description="If true, input port 3 is reverted to default value, after value was sent."/>
+			<property name="port4ToDefaultAfterSend"
+					  type="boolean"
+					  value="false"
+					  description="If true, input port 4 is reverted to default value, after value was sent."/>
         </properties>
 
     </componentType>

--- a/Documentation/ACS-Help/HTML/Plugins/processors/StringFormatter.htm
+++ b/Documentation/ACS-Help/HTML/Plugins/processors/StringFormatter.htm
@@ -29,6 +29,14 @@
       <li><strong>defaultIn3Double [double]:</strong> The default value of in3Double. Used if there is no input port value.</li>
       <li><strong>defaultIn4Integer [integer]:</strong> The default value of in4Integer. Used if there is no input port value.</li>
       <li><strong>sendOnlyByEvent [boolean]:</strong> Only sends the value of the formatted string, if the event sendFormattedStr is received.</li>
+      <li>
+        <strong>port1ToDefaultAfterSend [boolean]:</strong> If true (default: false) input port 1 is reverted to the default value (property 'defaultIn1String')
+        after the formatted result value was sent, triggered by a different value sent to input port 'in1String'.
+        This functionality can be useful, if some kind of action string is constructed using the StringFormatter plugin and a part of it should be sent exactly once triggering an one-time action.
+      </li>
+      <li>
+        <strong>port[2-4]ToDefaultAfterSend [boolean]:</strong> Analog functionality for input ports 2-4 as described for 'port1ToDefaultAfterSend' above.
+      </li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
I needed to send a formatted string via the serial port which is formatted like this:
`<mousePosX> <mousePosY> <mouseFn> <key1> <key2> <key3>;`

and used the StringFormatter plugin to achieve this format. However I needed a possiblity to send some properties only once, like e.g. "mouseFn", which should trigger an action exactly once. To achieve this, this PR adds the possibilty to reset the ports to the default value, after another value was sent, triggered by the corresponding input port.

for details see updated documentation, which will be added soon to this PR.