### PR TITLE
reverted to old polling strategy instead of call of (nicer) "portControler.poll()"

### DIFF
--- a/ARE/components/processor.serialport/src/main/java/eu/asterics/component/processor/serialport/SerialPortInstance.java
+++ b/ARE/components/processor.serialport/src/main/java/eu/asterics/component/processor/serialport/SerialPortInstance.java
@@ -25,7 +25,9 @@
 
 package eu.asterics.component.processor.serialport;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -34,16 +36,13 @@ import java.util.logging.Logger;
 
 import eu.asterics.mw.cimcommunication.CIMPortController;
 import eu.asterics.mw.cimcommunication.CIMPortManager;
-//import eu.asterics.component.sensor.acceleration.AccelerationInstance.OutputPort;
 import eu.asterics.mw.data.ConversionUtils;
-import eu.asterics.mw.model.runtime.AbstractRuntimeComponentInstance;
-import eu.asterics.mw.model.runtime.IRuntimeEventListenerPort;
-import eu.asterics.mw.model.runtime.IRuntimeEventTriggererPort;
-import eu.asterics.mw.model.runtime.IRuntimeInputPort;
-import eu.asterics.mw.model.runtime.IRuntimeOutputPort;
+import eu.asterics.mw.model.runtime.*;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeInputPort;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeOutputPort;
 import eu.asterics.mw.services.AstericsErrorHandling;
+
+//import eu.asterics.component.sensor.acceleration.AccelerationInstance.OutputPort;
 
 /**
  * 
@@ -426,13 +425,13 @@ public class SerialPortInstance extends AbstractRuntimeComponentInstance {
                 running = true;
                 try {
                     while (running) {
-                        Byte read = portController.poll();
-                        if (read != null) {
-                            handlePacketReceived(read);
+                        while (in.available() > 0) {
+                            handlePacketReceived((byte) in.read());
                         }
+                        Thread.sleep(10);
                     }
-                } catch (IOException e) {
-                    logger.log(Level.WARNING, "IOException in polling data in SerialPort module.");
+                } catch (IOException | InterruptedException e) {
+                    logger.log(Level.WARNING, "Exception in polling data in SerialPort module.");
                     closeAll();
                 }
                 logger.log(Level.FINE, "SerialPort module: stopped reading thread.");

--- a/Documentation/ACS-Help/HTML/Plugins/processors/SerialPort.htm
+++ b/Documentation/ACS-Help/HTML/Plugins/processors/SerialPort.htm
@@ -15,18 +15,36 @@
       <li><strong>send [string]:</strong> string which will be sent to the microcontroller / embedded module</li>
 	  <li><strong>sendBytes [byte]:</strong> bytes to be sent to the serial port.</li>
     </ul>
+    <p>
+        <i>Note:</i> Any data sent to one of the input ports tries to open the given COM port or serial device with given cimId, if the port is not currently open.
+        Therefore sending a byte/command to an input port can be used to trigger a CIM-rescan or retry to open a device with specified cimId. The current status
+        can be monitored by output values of "opPortStatus".
+    </p>
+
     <h2>Output Port Description</h2>
     <ul>
       <li><strong>received [string]:</strong> string which has been received (was sent from the microcontroller / embedded module)</li>
 	  <li><strong>receivedBytes [byte]:</strong> received bytes from the serial port. </li>
+	  <li>
+          <strong>opPortStatus [string]:</strong> status for mode with specified property "cimId". The following outputs are possible:
+          <ul>
+              <li>"IN_PORT_RESCAN": sent if CIM scanning is currently in progress and was not just triggered</li>
+              <li>"NEW_PORT_RESCAN": sent if a new CIM scanning was just triggered and CIM scanning is now in progress</li>
+          </ul>
+
+      </li>
     </ul>
     <h2>Properties </h2>
     <ul>
       <li><strong>ComPort [string]:</strong> Defines the COM Port of the target serial device. e.g. COM0 or /dev/ttyS0</li>
       <li><strong>BaudRate [integer]:</strong> Defines the Baudrate for the communication. It must match the baudrate of the target device</li>
-	  <li><strong>sendStringTerminator [combobox selection]:</strong>Append a character when sending the string, e.g. CR, LF, CR+LF, 0</li>
-	  <li><strong>receiveStringTerminator [combobox selection]:</strong>wait for a termination character when receiving characters (-> receive a string) </li>
-	  <li><strong>sendBytesBufferSize [integer]:</strong>Wait for the given number of bytes before sending them to the serial port.</li>
+	  <li><strong>sendStringTerminator [combobox selection]:</strong> Append a character when sending the string, e.g. CR, LF, CR+LF, 0</li>
+	  <li><strong>receiveStringTerminator [combobox selection]:</strong> wait for a termination character when receiving characters (-> receive a string) </li>
+	  <li><strong>sendBytesBufferSize [integer]:</strong> Wait for the given number of bytes before sending them to the serial port.</li>
+	  <li>
+          <strong>cimId [string]:</strong> If specified it is tried to open a raw COM port for a device with the given CIM-ID. If no device with the given CIM-ID is found a CIM rescan is triggered.
+          The accepted format is a hex-value with prefix "0x", e.g. "0xa401" for FLipMouse. Status of CIM scan/rescan is sent to "opPortStatus" - see port description for details.
+      </li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
reverted to old polling strategy instead of call of (nicer) "portControler.poll()" because not all CIMControllers are implementing the poll() function, which led to the following Exception (reported by Barbara Wakolbinger):

```
[java] 2019-03-22 11:03:22.501 SEVERE [Main$1 uncaughtException] in Thread <Thread-11>: method eu.asterics.mw.cimcommunication.CIMPortController.poll() not implemented
[java] java.lang.RuntimeException: method eu.asterics.mw.cimcommunication.CIMPortController.poll() not implemented
[java]     at eu.asterics.mw.cimcommunication.CIMPortController.poll(CIMPortController.java:128)
[java]     at eu.asterics.component.processor.serialport.SerialPortInstance$3.run(SerialPortInstance.java:429)
[java]     at java.lang.Thread.run(Thread.java:748)
```