### PR TITLE
Deinhofer/are properties comments and insertion order

### DIFF
--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/Main.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/Main.java
@@ -49,8 +49,7 @@ import eu.asterics.mw.utils.OSUtils;
 /**
  * Starting point for ARE middleware
  *
- * @author Nearchos Paspallis [nearchos@cs.ucy.ac.cy] Date: Aug 23, 2010 Time:
- *         11:36:14 AM
+ * @author Nearchos Paspallis [nearchos@cs.ucy.ac.cy] Date: Aug 23, 2010 Time: 11:36:14 AM
  */
 public class Main implements BundleActivator {
     public static final String ASAPI_ENABLE_ARE_AUTODETECTION_PROPKEY = "ASAPI.enableAREAutoDetection";
@@ -73,13 +72,22 @@ public class Main implements BundleActivator {
     public void start(final BundleContext context) throws Exception {
         logger = AstericsErrorHandling.instance.getLogger();
 
-        //set default uncaught exception handler to get logged messages in case of exception.
+        // set default uncaught exception handler to get logged messages in case of exception.
         Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler() {
             @Override
             public void uncaughtException(Thread t, Throwable e) {
                 logger.log(Level.SEVERE, "in Thread <" + t.getName() + ">: " + e.getMessage(), e);
             }
         });
+
+        // Set default values for ASAPI interface which is used for ACS to ARE connection
+        AREProperties.instance.setDefaultPropertyValue(ASAPI_ENABLE_ACS_PORT_CONNECTION, "1",
+                "Enables/Disables ASAPI port registration for ACS. 1=ACS may connect to ARE through the port specified with the key '"
+                        + Activator.ASAPI_ACS_PORT_NUMBER_PROPKEY + "'. 0=ACS may not connect to the ARE.");
+        AREProperties.instance.setDefaultPropertyValue(ASAPI_ENABLE_ARE_AUTODETECTION_PROPKEY, "1",
+                "Enables/Disables ARE autodetection by the ACS. 1=Autodetection enabled, 0=Autodetection disabled");
+        AREProperties.instance.setDefaultPropertyValue(Activator.ASAPI_ACS_PORT_NUMBER_PROPKEY, String.valueOf(Activator.ASAPI_ACS_PORT_NUMBER_DEFAULT),
+                "Sets the ASAPI port number which is used by the ACS to connect to the ARE.");
 
         // Check if not 32bit
         String bits = System.getProperty("sun.arch.data.model");
@@ -123,10 +131,7 @@ public class Main implements BundleActivator {
                     DeploymentManager.instance.setStatus(AREStatus.OK);
                     AstericsErrorHandling.instance.setStatusObject(AREStatus.OK.toString(), "", "");
 
-                    if (!AREProperties.instance.containsKey(ASAPI_ENABLE_ACS_PORT_CONNECTION)
-                            || AREProperties.instance.checkProperty(ASAPI_ENABLE_ACS_PORT_CONNECTION, "1")) {
-                        // set default value, if property was not in file.
-                        AREProperties.instance.setProperty(ASAPI_ENABLE_ACS_PORT_CONNECTION, "1");
+                    if (AREProperties.instance.checkProperty(ASAPI_ENABLE_ACS_PORT_CONNECTION, "1")) {
                         logger.info("ASAPI: Enabling ACS port connection");
                         Thread asapiServerThread = new Thread(new Activator());
                         asapiServerThread.start();
@@ -134,11 +139,7 @@ public class Main implements BundleActivator {
                         logger.info("ASAPI: ACS port connection disabled");
                     }
 
-                    if (!AREProperties.instance.containsKey(ASAPI_ENABLE_ARE_AUTODETECTION_PROPKEY)
-                            || AREProperties.instance.checkProperty(ASAPI_ENABLE_ARE_AUTODETECTION_PROPKEY, "1")) {
-                        // set default value, if property was not in file.
-                        AREProperties.instance.setProperty(ASAPI_ENABLE_ARE_AUTODETECTION_PROPKEY, "1");
-
+                    if (AREProperties.instance.checkProperty(ASAPI_ENABLE_ARE_AUTODETECTION_PROPKEY, "1")) {
                         logger.info("ASAPI: Enabling ARE auto detection");
                         Thread udpThread = new Thread(new UDPThread());
                         udpThread.start();
@@ -177,8 +178,7 @@ public class Main implements BundleActivator {
     }
 
     /**
-     * Show non-modal info/warning/error message not disable-able by
-     * areProperties.
+     * Show non-modal info/warning/error message not disable-able by areProperties.
      * 
      * @param message
      * @param messageType

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/asapi/Activator.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/asapi/Activator.java
@@ -45,10 +45,7 @@ public class Activator implements Runnable {
      * @return
      */
     private int getPortNumber() {
-        String ASAPIACSPort = AREProperties.instance.getProperty(ASAPI_ACS_PORT_NUMBER_PROPKEY,
-                String.valueOf(ASAPI_ACS_PORT_NUMBER_DEFAULT));
-        // set back default value, if property was not in file.
-        AREProperties.instance.setProperty(ASAPI_ACS_PORT_NUMBER_PROPKEY, ASAPIACSPort);
+        String ASAPIACSPort = AREProperties.instance.getProperty(ASAPI_ACS_PORT_NUMBER_PROPKEY);
 
         try {
             return Integer.valueOf(ASAPIACSPort);

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
@@ -82,7 +82,7 @@ import eu.asterics.mw.services.IAREEventListener;
  *         Time: 2:14:37 PM
  */
 public class AstericsGUI implements IAREEventListener {
-    private static int DEFAULT_FONT_SIZE = 18;
+    private final static int DEFAULT_FONT_SIZE = 18;
     private static String DEFAULT_FONT_SIZE_PROPERTY = "ARE.gui.font.size";
     public final static String ARE_VERSION = "#{APPLICATION_VERSION_NUMBER}#";
     static int DEFAULT_SCREEN_X = 0;
@@ -121,49 +121,57 @@ public class AstericsGUI implements IAREEventListener {
     public AstericsGUI(BundleContext bundleContext) {
         super();
 
-        DEFAULT_FONT_SIZE = new Integer(AREProperties.instance.getProperty(DEFAULT_FONT_SIZE_PROPERTY, String.valueOf(DEFAULT_FONT_SIZE)));
-        AstericsErrorHandling.instance.getLogger().info(DEFAULT_FONT_SIZE_PROPERTY + "=" + DEFAULT_FONT_SIZE);
-        AREProperties.instance.setProperty(DEFAULT_FONT_SIZE_PROPERTY, Integer.toString(DEFAULT_FONT_SIZE));
+        AREProperties.instance.setDefaultPropertyValue(DEFAULT_FONT_SIZE_PROPERTY, String.valueOf(DEFAULT_FONT_SIZE), "The default font size for the ARE GUI.");
+        Integer fontSize = DEFAULT_FONT_SIZE;
+        try {
+            fontSize = new Integer(AREProperties.instance.getProperty(DEFAULT_FONT_SIZE_PROPERTY));
+        } catch (NumberFormatException e) {
+            AstericsErrorHandling.instance.getLogger().warning("Could not parse numeric fontSize for ARE GUI: key: " + DEFAULT_FONT_SIZE_PROPERTY + "="
+                    + AREProperties.instance.getProperty(DEFAULT_FONT_SIZE_PROPERTY));
+        }
 
-        UIManager.getLookAndFeelDefaults().put("defaultFont", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
+        AstericsErrorHandling.instance.getLogger().info(DEFAULT_FONT_SIZE_PROPERTY + "=" + fontSize);
+        AREProperties.instance.setProperty(DEFAULT_FONT_SIZE_PROPERTY, Integer.toString(fontSize));
+
+        UIManager.getLookAndFeelDefaults().put("defaultFont", new Font("Arial", Font.PLAIN, fontSize));
 
         UIManager.get("messageFont");
-        UIManager.put("OptionPane.messageFont", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
+        UIManager.put("OptionPane.messageFont", new Font("Arial", Font.PLAIN, fontSize));
 
         UIManager.get("messageForeground");
         UIManager.put("OptionPane.messageForeground", Color.black);
 
-        UIManager.put("Button.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("ToggleButton.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("RadioButton.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("CheckBox.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("ColorChooser.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("ComboBox.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("Label.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("List.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("MenuBar.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("MenuItem.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("RadioButtonMenuItem.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("CheckBoxMenuItem.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("Menu.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("PopupMenu.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("OptionPane.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("Panel.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("ProgressBar.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("ScrollPane.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("Viewport.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("TabbedPane.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("Table.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("TableHeader.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("TextField.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("PasswordField.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("TextArea.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("TextPane.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("EditorPane.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("TitledBorder.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("ToolBar.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("ToolTip.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
-        UIManager.put("Tree.font", new Font("Arial", Font.PLAIN, DEFAULT_FONT_SIZE));
+        UIManager.put("Button.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("ToggleButton.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("RadioButton.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("CheckBox.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("ColorChooser.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("ComboBox.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("Label.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("List.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("MenuBar.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("MenuItem.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("RadioButtonMenuItem.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("CheckBoxMenuItem.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("Menu.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("PopupMenu.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("OptionPane.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("Panel.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("ProgressBar.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("ScrollPane.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("Viewport.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("TabbedPane.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("Table.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("TableHeader.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("TextField.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("PasswordField.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("TextArea.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("TextPane.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("EditorPane.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("TitledBorder.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("ToolBar.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("ToolTip.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("Tree.font", new Font("Arial", Font.PLAIN, fontSize));
 
         // logger = AstericsErrorHandling.instance.getLogger();
         screenSize = Toolkit.getDefaultToolkit().getScreenSize();
@@ -525,10 +533,10 @@ public class AstericsGUI implements IAREEventListener {
         });
 
     }
-    
+
     public void cleanupPanel() {
         SwingUtilities.invokeLater(new Runnable() {
-            
+
             @Override
             public void run() {
                 AstericsErrorHandling.instance.getLogger().fine("Cleaning Desktop panel...");

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/ControlPane.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/ControlPane.java
@@ -56,20 +56,20 @@ import javax.swing.WindowConstants;
 import javax.swing.border.TitledBorder;
 
 import eu.asterics.mw.are.AREProperties;
+import static eu.asterics.mw.are.AREProperties.*;
 import eu.asterics.mw.utils.OSUtils;
 import org.osgi.framework.BundleContext;
 
 import eu.asterics.mw.are.AREStatus;
 import eu.asterics.mw.are.AsapiSupport;
 import eu.asterics.mw.are.exceptions.AREAsapiException;
+import eu.asterics.mw.services.AREServices;
 import eu.asterics.mw.services.AstericsErrorHandling;
 
 public class ControlPane extends JPanel {
 
     private static final int CONTROLPANEL_WIDTH = 30;
-    private Logger logger = AstericsErrorHandling.instance.getLogger();
-    private static final String DEFAULT_REST_PORT = "8081";
-    private static final String PROPTERTY_REST_PORT = "ARE.webservice.port.REST";
+    private Logger logger = AstericsErrorHandling.instance.getLogger();    
 
     private BundleContext bundleContext;
     private JPanel jplPanel, iconPanel, mainPanel;
@@ -267,20 +267,14 @@ public class ControlPane extends JPanel {
             pencilLabel = new ControlPanelLabel(getFullURL(PENCIL_ICON_PATH), getFullURL(PENCIL_ICON_PATH_RO), "Edit current model in WebACS") {
                 @Override
                 public void onMouseClick() {
-                    String webACSPath = "webapps/WebACS/index.html?autoConnect=true&autoDownloadModel=true";
-                    String url = MessageFormat.format("http://localhost:{0}/{1}", getCurrentRestPort(), webACSPath);
-                    try {
-                        OSUtils.openURL(url, OSUtils.OS_NAMES.ALL);
-                    } catch (IOException e) {
-                        logger.log(Level.SEVERE, "error opening WebACS for current model.", e);
-                    }
+                    AREServices.instance.editModel();                    
                 }
             };
 
             globeLabel = new ControlPanelLabel(getFullURL(GLOBE_ICON_PATH), getFullURL(GLOBE_ICON_PATH_RO), "Open ARE Webserver Startpage") {
                 @Override
                 public void onMouseClick() {
-                    String url = MessageFormat.format("http://localhost:{0}/", getCurrentRestPort());
+                    String url = MessageFormat.format("http://localhost:{0}/",AREProperties.instance.getProperty(ARE_WEBSERVICE_PORT_REST_KEY));
                     try {
                         OSUtils.openURL(url, OSUtils.OS_NAMES.ALL);
                     } catch (IOException e) {
@@ -697,13 +691,5 @@ public class ControlPane extends JPanel {
 
     private URL getFullURL(String relativePath) {
         return bundleContext.getBundle().getResource(relativePath);
-    }
-
-    private String getCurrentRestPort() {
-        String port = AREProperties.instance.getProperty(PROPTERTY_REST_PORT);
-        if(port == null || port.isEmpty()) {
-            port = DEFAULT_REST_PORT;
-        }
-        return port;
     }
 }

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/ControlPane.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/ControlPane.java
@@ -69,7 +69,7 @@ import eu.asterics.mw.services.AstericsErrorHandling;
 public class ControlPane extends JPanel {
 
     private static final int CONTROLPANEL_WIDTH = 30;
-    private Logger logger = AstericsErrorHandling.instance.getLogger();    
+    private Logger logger = AstericsErrorHandling.instance.getLogger();
 
     private BundleContext bundleContext;
     private JPanel jplPanel, iconPanel, mainPanel;
@@ -267,14 +267,14 @@ public class ControlPane extends JPanel {
             pencilLabel = new ControlPanelLabel(getFullURL(PENCIL_ICON_PATH), getFullURL(PENCIL_ICON_PATH_RO), "Edit current model in WebACS") {
                 @Override
                 public void onMouseClick() {
-                    AREServices.instance.editModel();                    
+                    AREServices.instance.editModel();
                 }
             };
 
             globeLabel = new ControlPanelLabel(getFullURL(GLOBE_ICON_PATH), getFullURL(GLOBE_ICON_PATH_RO), "Open ARE Webserver Startpage") {
                 @Override
                 public void onMouseClick() {
-                    String url = MessageFormat.format("http://localhost:{0}/",AREProperties.instance.getProperty(ARE_WEBSERVICE_PORT_REST_KEY));
+                    String url = MessageFormat.format("http://localhost:{0}/", AREProperties.instance.getProperty(ARE_WEBSERVICE_PORT_REST_KEY));
                     try {
                         OSUtils.openURL(url, OSUtils.OS_NAMES.ALL);
                     } catch (IOException e) {
@@ -465,8 +465,7 @@ public class ControlPane extends JPanel {
         exitLabel.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent me) {
-                int n = JOptionPane.showConfirmDialog(null, "Are you sure to stop and close the ARE?", "ARE Exit",
-                        JOptionPane.YES_NO_OPTION);
+                int n = JOptionPane.showConfirmDialog(null, "Are you sure to stop and close the ARE?", "ARE Exit", JOptionPane.YES_NO_OPTION);
                 if (n == JOptionPane.YES_OPTION) {
                     astericsGUI.closeAction();
                 }
@@ -600,9 +599,8 @@ public class ControlPane extends JPanel {
         // cpWrapperPanel.setLayout(new BoxLayout(cpWrapperPanel,axis));
         iconPanel.setLayout(new BoxLayout(iconPanel, axis));
         /*
-         * if (axis==BoxLayout.Y_AXIS) setPreferredSize(new Dimension
-         * (VERTICAL_BAR_WIDTH,VERTICAL_BAR_HEIGHT)); else setPreferredSize(new
-         * Dimension (HORIZONTAL_BAR_WIDTH,HORIZONTAL_BAR_HEIGHT));
+         * if (axis==BoxLayout.Y_AXIS) setPreferredSize(new Dimension (VERTICAL_BAR_WIDTH,VERTICAL_BAR_HEIGHT)); else setPreferredSize(new Dimension
+         * (HORIZONTAL_BAR_WIDTH,HORIZONTAL_BAR_HEIGHT));
          */
         mainPanel.revalidate();
 

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/TabbedPane.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/TabbedPane.java
@@ -56,6 +56,8 @@ import eu.asterics.mw.model.deployment.IRuntimeModel;
  *         Date: Oct 10, 2011
  */
 public class TabbedPane extends JPanel {
+    public static final String SHOW_ERROR_DIALOGS = "showErrorDialogs";
+    public static final String BACKGROUND_COLOR = "background_color";
     private static final Color DEFAULT_BACKGROUND_COLOR = new Color(-11435361);
 
     private AstericsGUI parent;
@@ -154,8 +156,8 @@ public class TabbedPane extends JPanel {
 
         AREProperties props = AREProperties.instance;
 
-        if (props.containsKey("showErrorDialogs")) {
-            if (Integer.parseInt(props.getProperty("showErrorDialogs")) == 1) {
+        if (props.containsKey(SHOW_ERROR_DIALOGS)) {
+            if (Integer.parseInt(props.getProperty(SHOW_ERROR_DIALOGS)) == 1) {
                 showErrorGuiBox.setSelected(true);
             } else {
                 showErrorGuiBox.setSelected(false);
@@ -175,8 +177,8 @@ public class TabbedPane extends JPanel {
 
         JPanel colorPanel = new JPanel();
         colorPanel.setLayout(new BoxLayout(colorPanel, BoxLayout.Y_AXIS));
-        if (props.containsKey("background_color")) {
-            tcc = new JColorChooser(new Color(Integer.parseInt(props.getProperty("background_color"))));
+        if (props.containsKey(BACKGROUND_COLOR)) {
+            tcc = new JColorChooser(new Color(Integer.parseInt(props.getProperty(BACKGROUND_COLOR))));
         } else {
             tcc = new JColorChooser(DEFAULT_BACKGROUND_COLOR); // default
         }
@@ -189,27 +191,20 @@ public class TabbedPane extends JPanel {
 
     void storeDefaultProperties() {
         AREProperties props = AREProperties.instance;
-
-        if (!props.containsKey("background_color")) {
-            props.setProperty("background_color", Integer.toString(DEFAULT_BACKGROUND_COLOR.getRGB()));
-        }
-
-        if (!props.containsKey("showErrorDialogs")) {
-            props.setProperty("showErrorDialogs", "1");
-        }
-
-        props.storeProperties();
+       
+        props.setDefaultPropertyValue(BACKGROUND_COLOR, Integer.toString(DEFAULT_BACKGROUND_COLOR.getRGB()), "The background colour of the ARE desktop. Please change the value in the ARE GUI.");
+        props.setDefaultPropertyValue(SHOW_ERROR_DIALOGS, "1", "Flag to turn off showing the error dialog. 1=show errors, 0=don't show errors");
     }
 
     void storeProperties() {
         AREProperties props = AREProperties.instance;
 
-        props.setProperty("background_color", Integer.toString(tcc.getColor().getRGB()));
+        props.setProperty(BACKGROUND_COLOR, Integer.toString(tcc.getColor().getRGB()));
 
         if (showErrorGuiBox.isSelected()) {
-            props.setProperty("showErrorDialogs", "1");
+            props.setProperty(SHOW_ERROR_DIALOGS, "1");
         } else {
-            props.setProperty("showErrorDialogs", "0");
+            props.setProperty(SHOW_ERROR_DIALOGS, "0");
         }
 
         props.storeProperties();

--- a/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
@@ -39,6 +39,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.concurrent.Callable;
@@ -65,6 +66,8 @@ import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
+import eu.asterics.mw.are.AREProperties;
+import static eu.asterics.mw.are.AREProperties.*;
 import eu.asterics.mw.are.AREStatus;
 import eu.asterics.mw.are.DeploymentManager;
 import eu.asterics.mw.are.exceptions.AREAsapiException;
@@ -76,6 +79,7 @@ import eu.asterics.mw.model.deployment.IRuntimeModel;
 import eu.asterics.mw.model.deployment.impl.ModelState;
 import eu.asterics.mw.model.runtime.IRuntimeComponentInstance;
 import eu.asterics.mw.services.ResourceRegistry.RES_TYPE;
+import eu.asterics.mw.utils.OSUtils;
 
 /*
  *    AsTeRICS - Assistive Technology Rapid Integration and Construction Set
@@ -485,6 +489,19 @@ public class AREServices implements IAREServices {
             AstericsModelExecutionThreadPool.getInstance().switchToFallbackPool();
         }
     }
+    
+    /**
+     * Opens the currently deployed model in the WebACS for editing. 
+     */
+    public void editModel() {
+        String webACSPath = "webapps/WebACS/index.html?autoConnect=true&autoDownloadModel=true";
+        String url = MessageFormat.format("http://localhost:{0}/{1}", AREProperties.instance.getProperty(ARE_WEBSERVICE_PORT_REST_KEY), webACSPath);
+        try {
+            OSUtils.openURL(url, OSUtils.OS_NAMES.ALL);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "error opening WebACS for current model.", e);
+        }        
+    }    
 
     /**
      * Creates an error message for an error dialog and internally logs the

--- a/ARE/middleware/src/main/java/eu/asterics/mw/services/AstericsModelExecutionThreadPool.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/services/AstericsModelExecutionThreadPool.java
@@ -66,14 +66,11 @@ import eu.asterics.mw.are.AREProperties;
  */
 
 /**
- * This thread pool is used to perform the execution of a deployed model. The
- * default approach is a single threaded approach, this means that start, stop,
- * setProperty, sendData and receiveEvent are all executed within the same
- * single thread.
+ * This thread pool is used to perform the execution of a deployed model. The default approach is a single threaded approach, this means that start, stop,
+ * setProperty, sendData and receiveEvent are all executed within the same single thread.
  * 
- * @deprecated: The multi-threaded approach is deprecated. If used, there is no
- *              guarantee for thread synchronization and data integrity when
- *              calling start, stop, setProperty, sendData or receiveEvent.
+ * @deprecated: The multi-threaded approach is deprecated. If used, there is no guarantee for thread synchronization and data integrity when calling start,
+ *              stop, setProperty, sendData or receiveEvent.
  * @author mad
  *
  */
@@ -81,11 +78,10 @@ public class AstericsModelExecutionThreadPool {
     private static final int DEFAULT_EXECUTOR_QUEUE_SIZE = 500;
     // The default submit timeout for a task when called blocking with
     // execAndWaitOnModelExecutorLifecycleThread(...).
-    public static int TASK_SUBMIT_TIMEOUT = 20000;
+    public final static int DEFAULT_TASK_SUBMIT_TIMEOUT = 20000;
+    public static int TASK_SUBMIT_TIMEOUT = DEFAULT_TASK_SUBMIT_TIMEOUT;
     /*
-     * Set default value to 1, because only in the single threaded approach
-     * there is deterministic execution of data propagation and event
-     * notification
+     * Set default value to 1, because only in the single threaded approach there is deterministic execution of data propagation and event notification
      */
     private static final int DEFAULT_POOL_SIZE = 1;
 
@@ -107,8 +103,7 @@ public class AstericsModelExecutionThreadPool {
         @Override
         public Thread newThread(Runnable r) {
             String threadName = MODEL_EXECUTOR_LIFECYCLE + "-Fallback-" + fallbackNr++;
-            logger.warning("ModelExecutor [" + Thread.currentThread().getName()
-                    + "]: Switching to fallbackPool with Thread: " + threadName);
+            logger.warning("ModelExecutor [" + Thread.currentThread().getName() + "]: Switching to fallbackPool with Thread: " + threadName);
 
             Thread newThread = Executors.defaultThreadFactory().newThread(r);
             newThread.setName(threadName);
@@ -122,25 +117,26 @@ public class AstericsModelExecutionThreadPool {
     /*
      * = Executors .newSingleThreadExecutor(new ThreadFactory() {
      * 
-     * @Override public Thread newThread(Runnable arg0) { logger.fine(
-     * "Creating Thread: "+MODEL_EXECUTOR_LIFECYCLE);
+     * @Override public Thread newThread(Runnable arg0) { logger.fine( "Creating Thread: "+MODEL_EXECUTOR_LIFECYCLE);
      * 
-     * Thread newThread=Executors.defaultThreadFactory().newThread(arg0);
-     * newThread.setName(MODEL_EXECUTOR_LIFECYCLE); return newThread; } });
+     * Thread newThread=Executors.defaultThreadFactory().newThread(arg0); newThread.setName(MODEL_EXECUTOR_LIFECYCLE); return newThread; } });
      */
     private AstericsModelExecutionThreadPool() {
-        TASK_SUBMIT_TIMEOUT = new Integer(
-                AREProperties.instance.getProperty(TASK_SUBMIT_TIMEOUT_PROPERTY, String.valueOf(TASK_SUBMIT_TIMEOUT)));
+        AREProperties.instance.setDefaultPropertyValue(TASK_SUBMIT_TIMEOUT_PROPERTY, String.valueOf(DEFAULT_TASK_SUBMIT_TIMEOUT),
+                "This timeout in [ms] is used to start/stop a model and do other tasks related to models. If you get a timeout during ARE/model start try to increase the value. Especially on a Raspberry Pi this can be necessary.");
+        try {
+            TASK_SUBMIT_TIMEOUT = new Integer(AREProperties.instance.getProperty(TASK_SUBMIT_TIMEOUT_PROPERTY));
+        } catch (NumberFormatException e) {
+            TASK_SUBMIT_TIMEOUT = DEFAULT_TASK_SUBMIT_TIMEOUT;
+        }
         logger.info(TASK_SUBMIT_TIMEOUT_PROPERTY + "=" + TASK_SUBMIT_TIMEOUT);
-        AREProperties.instance.setProperty(TASK_SUBMIT_TIMEOUT_PROPERTY, Integer.toString(TASK_SUBMIT_TIMEOUT));
 
         int poolSize = 1;
 
         modelExecutorLifecycle = createExecutorService();
         pool = modelExecutorLifecycle;
         if (poolSize > 1) {
-            logger.warning("\n\nWARNING: Multi-threaded mode ist DEPRECATED! - " + THREAD_POOL_SIZE
-                    + " > 1, creating thread pool\n\n");
+            logger.warning("\n\nWARNING: Multi-threaded mode ist DEPRECATED! - " + THREAD_POOL_SIZE + " > 1, creating thread pool\n\n");
             pool = Executors.newFixedThreadPool(poolSize, new ThreadFactory() {
                 private int threadNr = 0;
 
@@ -161,8 +157,7 @@ public class AstericsModelExecutionThreadPool {
 
         // pool = Executors.newCachedThreadPool();
         /*
-         * pool = new ThreadPoolExecutor(5, 20, 60, TimeUnit.SECONDS, new
-         * LinkedBlockingQueue<Runnable>(100));
+         * pool = new ThreadPoolExecutor(5, 20, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(100));
          */
     }
 
@@ -171,13 +166,11 @@ public class AstericsModelExecutionThreadPool {
     }
 
     /**
-     * Executes (non-blocking) the given Runnable either in the
-     * modelExecutorLifecycle thread (single threaded approach) or in a thread
-     * pool of userdefined size.
+     * Executes (non-blocking) the given Runnable either in the modelExecutorLifecycle thread (single threaded approach) or in a thread pool of userdefined
+     * size.
      * 
-     * @Note: In single threaded approach: the taks is operated off a bounded
-     *        queue of size DEFAULT_EXECUTOR_QUEUE_SIZE. If the queue is full,
-     *        the task is rejected to prevent knocking out the ARE.
+     * @Note: In single threaded approach: the taks is operated off a bounded queue of size DEFAULT_EXECUTOR_QUEUE_SIZE. If the queue is full, the task is
+     *        rejected to prevent knocking out the ARE.
      * @param r
      */
     public void execute(Runnable r) {
@@ -195,45 +188,35 @@ public class AstericsModelExecutionThreadPool {
     }
 
     /**
-     * Submits (blocking) the given Callable and waits until completion either
-     * in the modelExecutorLifecycle thread (single threaded approach) or in a
-     * thread pool of userdefined size.
+     * Submits (blocking) the given Callable and waits until completion either in the modelExecutorLifecycle thread (single threaded approach) or in a thread
+     * pool of userdefined size.
      * 
-     * @Note: In single threaded approach: the taks is operated off a bounded
-     *        queue of size DEFAULT_EXECUTOR_QUEUE_SIZE. If the queue is full,
-     *        the task is rejected to prevent knocking out the ARE.
+     * @Note: In single threaded approach: the taks is operated off a bounded queue of size DEFAULT_EXECUTOR_QUEUE_SIZE. If the queue is full, the task is
+     *        rejected to prevent knocking out the ARE.
      * @param r
      */
     // Removed submit method because, the user should either use .execute to
     // asynchronously call a task or execAndWaitOnModelExecutorLifecycleThread
     // synchronously with timeout.
     /*
-     * public <V> V submit(Callable<V> r) throws InterruptedException,
-     * ExecutionException, TimeoutException { try{
-     * if(Thread.currentThread().getName().startsWith(MODEL_EXECUTOR_LIFECYCLE))
-     * { return r.call(); } else { //System.out.print("s"); Future<V>
-     * f=pool.submit(r); try{ return
-     * f.get(TASK_SUBMIT_TIMEOUT,TimeUnit.MILLISECONDS); }catch(TimeoutException
-     * e) { logger.warning("["+Thread.currentThread().getName()+
-     * "]: Task execution timeouted, trying to cancel task"); if(f!=null) {
-     * f.cancel(true); } throw(e); } } }catch(RejectedExecutionException re) {
-     * System.out.print("-"); return null; }catch(InterruptedException |
-     * ExecutionException | TimeoutException re) { throw re; }catch(Exception e)
-     * { throw new ExecutionException(e); } }
+     * public <V> V submit(Callable<V> r) throws InterruptedException, ExecutionException, TimeoutException { try{
+     * if(Thread.currentThread().getName().startsWith(MODEL_EXECUTOR_LIFECYCLE)) { return r.call(); } else { //System.out.print("s"); Future<V>
+     * f=pool.submit(r); try{ return f.get(TASK_SUBMIT_TIMEOUT,TimeUnit.MILLISECONDS); }catch(TimeoutException e) {
+     * logger.warning("["+Thread.currentThread().getName()+ "]: Task execution timeouted, trying to cancel task"); if(f!=null) { f.cancel(true); } throw(e); } }
+     * }catch(RejectedExecutionException re) { System.out.print("-"); return null; }catch(InterruptedException | ExecutionException | TimeoutException re) {
+     * throw re; }catch(Exception e) { throw new ExecutionException(e); } }
      */
 
     /**
-     * Executes (blocking, waits for termination) the given Runnable by the
-     * Thread instance "ModelExecutor". If the execution hangs a timeout arises
-     * after TASK_SUBMIT_TIMEOUT.
+     * Executes (blocking, waits for termination) the given Runnable by the Thread instance "ModelExecutor". If the execution hangs a timeout arises after
+     * TASK_SUBMIT_TIMEOUT.
      * 
      * @param r
      * @throws InterruptedException
      * @throws ExecutionException
      * @throws TimeoutException
      */
-    public void execAndWaitOnModelExecutorLifecycleThread(Runnable r)
-            throws InterruptedException, ExecutionException, TimeoutException {
+    public void execAndWaitOnModelExecutorLifecycleThread(Runnable r) throws InterruptedException, ExecutionException, TimeoutException {
         try {
             execAndWaitOnModelExecutorLifecycleThread(Executors.callable(r));
         } catch (Exception e) {
@@ -251,9 +234,8 @@ public class AstericsModelExecutionThreadPool {
     }
 
     /**
-     * Executes (blocking, waits for termination) the given Callable by the
-     * Thread instance "ModelExecutor". If the execution hangs a timeout arises
-     * after TASK_SUBMIT_TIMEOUT.
+     * Executes (blocking, waits for termination) the given Callable by the Thread instance "ModelExecutor". If the execution hangs a timeout arises after
+     * TASK_SUBMIT_TIMEOUT.
      * 
      * @param c
      * @throws Exception
@@ -272,9 +254,8 @@ public class AstericsModelExecutionThreadPool {
                 // lock or
                 // a blocked I/O call. So bypass old one and create a new one.
                 // To be sure that lifecycle tasks can always be executed.
-                logger.warning("[" + MODEL_EXECUTOR_LIFECYCLE
-                        + "]: Task execution rejected, queue full? Switching to new executor service."
-                        + modelExecutorLifecycle);
+                logger.warning(
+                        "[" + MODEL_EXECUTOR_LIFECYCLE + "]: Task execution rejected, queue full? Switching to new executor service." + modelExecutorLifecycle);
 
                 // first create new executor, but don't officially switch it now
                 // to prevent new tasks already queued in the new one.
@@ -288,50 +269,44 @@ public class AstericsModelExecutionThreadPool {
                 return ret;
             }
         } catch (TimeoutException e) {
-            logger.warning(
-                    "[" + MODEL_EXECUTOR_LIFECYCLE + "]: Task execution timeouted, switching to new executor service");
+            logger.warning("[" + MODEL_EXECUTOR_LIFECYCLE + "]: Task execution timeouted, switching to new executor service");
             switchToFallbackPoolInternal(createExecutorService());
             throw e;
         }
     }
 
     /**
-     * Internal implementation of either calling c.call on this thread or the
-     * submit method on the given executor. This depends on the name of the
-     * current thread. If the current thread's name starts with
-     * MODEL_EXECUTOR_LIFECYCLE it is assumed that the task is already running
-     * in the current model executor thread. (Note: This should always be
-     * exactly 1 thread, but in case of pool switching after a hanging task the
-     * fallback thread would also be treated as "equal".
+     * Internal implementation of either calling c.call on this thread or the submit method on the given executor. This depends on the name of the current
+     * thread. If the current thread's name starts with MODEL_EXECUTOR_LIFECYCLE it is assumed that the task is already running in the current model executor
+     * thread. (Note: This should always be exactly 1 thread, but in case of pool switching after a hanging task the fallback thread would also be treated as
+     * "equal".
      * 
      * @param c
      * @param executor
      * @return
      * @throws Exception
      */
-    private <V> V execAndWaitOnModelExecutorLifecycleThreadInternal(Callable<V> c, ExecutorService executor)
-            throws Exception {
+    private <V> V execAndWaitOnModelExecutorLifecycleThreadInternal(Callable<V> c, ExecutorService executor) throws Exception {
         if (Thread.currentThread().getName().startsWith(MODEL_EXECUTOR_LIFECYCLE)) {
             // We are already executed by the ModelExecutor Thread so just call
             // the
             // Runnable.run() method
-            AstericsErrorHandling.instance.getLogger().fine("ModelExecutor: Current thread: "
-                    + Thread.currentThread().getName() + ", running r.run() in this thread");
+            AstericsErrorHandling.instance.getLogger()
+                    .fine("ModelExecutor: Current thread: " + Thread.currentThread().getName() + ", running r.run() in this thread");
             return c.call();
         } else {
             // Execute with ModelExecutor and wait for response
             // "blocked execution"
-            AstericsErrorHandling.instance.getLogger().fine("ModelExecutor: Current thread: "
-                    + Thread.currentThread().getName() + ", Submitting on modelExecutorLifecycle thread");
+            AstericsErrorHandling.instance.getLogger()
+                    .fine("ModelExecutor: Current thread: " + Thread.currentThread().getName() + ", Submitting on modelExecutorLifecycle thread");
             Future<V> f = executor.submit(c);
             return f.get(TASK_SUBMIT_TIMEOUT, TimeUnit.MILLISECONDS);
         }
     }
 
     /**
-     * Creates a new thread pool of size 1 and exchanges (currently hanging)
-     * thread pools (modelExecutorLifecycle, pool) for model execution with the
-     * new instance.
+     * Creates a new thread pool of size 1 and exchanges (currently hanging) thread pools (modelExecutorLifecycle, pool) for model execution with the new
+     * instance.
      */
     private void switchToFallbackPoolInternal(ExecutorService fallbackPool) {
         // Each time an execution timeouts the caller can switch to a new
@@ -361,9 +336,8 @@ public class AstericsModelExecutionThreadPool {
     }
 
     /**
-     * @deprecated Creates a new thread pool of size 1 and exchanges (currently
-     *             hanging) thread pools (modelExecutorLifecycle, pool) for
-     *             model execution with the new instance.
+     * @deprecated Creates a new thread pool of size 1 and exchanges (currently hanging) thread pools (modelExecutorLifecycle, pool) for model execution with
+     *             the new instance.
      */
     @Deprecated
     public void switchToFallbackPool() {
@@ -380,8 +354,7 @@ public class AstericsModelExecutionThreadPool {
      * @return
      */
     private ExecutorService createExecutorService() {
-        return new ThreadPoolExecutor(1, 1, 10, TimeUnit.SECONDS,
-                new LinkedBlockingQueue<Runnable>(DEFAULT_EXECUTOR_QUEUE_SIZE), fallbackThreadFactory,
+        return new ThreadPoolExecutor(1, 1, 10, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(DEFAULT_EXECUTOR_QUEUE_SIZE), fallbackThreadFactory,
                 new ThreadPoolExecutor.AbortPolicy());
     }
 }

--- a/ARE/middleware/src/main/java/eu/asterics/mw/services/AstericsModelExecutionThreadPool.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/services/AstericsModelExecutionThreadPool.java
@@ -188,26 +188,6 @@ public class AstericsModelExecutionThreadPool {
     }
 
     /**
-     * Submits (blocking) the given Callable and waits until completion either in the modelExecutorLifecycle thread (single threaded approach) or in a thread
-     * pool of userdefined size.
-     * 
-     * @Note: In single threaded approach: the taks is operated off a bounded queue of size DEFAULT_EXECUTOR_QUEUE_SIZE. If the queue is full, the task is
-     *        rejected to prevent knocking out the ARE.
-     * @param r
-     */
-    // Removed submit method because, the user should either use .execute to
-    // asynchronously call a task or execAndWaitOnModelExecutorLifecycleThread
-    // synchronously with timeout.
-    /*
-     * public <V> V submit(Callable<V> r) throws InterruptedException, ExecutionException, TimeoutException { try{
-     * if(Thread.currentThread().getName().startsWith(MODEL_EXECUTOR_LIFECYCLE)) { return r.call(); } else { //System.out.print("s"); Future<V>
-     * f=pool.submit(r); try{ return f.get(TASK_SUBMIT_TIMEOUT,TimeUnit.MILLISECONDS); }catch(TimeoutException e) {
-     * logger.warning("["+Thread.currentThread().getName()+ "]: Task execution timeouted, trying to cancel task"); if(f!=null) { f.cancel(true); } throw(e); } }
-     * }catch(RejectedExecutionException re) { System.out.print("-"); return null; }catch(InterruptedException | ExecutionException | TimeoutException re) {
-     * throw re; }catch(Exception e) { throw new ExecutionException(e); } }
-     */
-
-    /**
      * Executes (blocking, waits for termination) the given Runnable by the Thread instance "ModelExecutor". If the execution hangs a timeout arises after
      * TASK_SUBMIT_TIMEOUT.
      * 

--- a/ARE/services/JNativeHook/src/main/java/eu/asterics/mw/jnativehook/NativeHookServices.java
+++ b/ARE/services/JNativeHook/src/main/java/eu/asterics/mw/jnativehook/NativeHookServices.java
@@ -43,6 +43,7 @@ import eu.asterics.mw.are.AREProperties;
 import eu.asterics.mw.are.AsapiSupport;
 import eu.asterics.mw.are.DeploymentManager;
 import eu.asterics.mw.are.exceptions.AREAsapiException;
+import eu.asterics.mw.services.AREServices;
 import eu.asterics.mw.services.AstericsErrorHandling;
 
 /**
@@ -56,9 +57,6 @@ import eu.asterics.mw.services.AstericsErrorHandling;
  */
 public class NativeHookServices implements NativeKeyListener {
     private static Logger logger = AstericsErrorHandling.instance.getLogger();
-
-    private static final String DEFAULT_REST_PORT = "8081";
-    private static final String PROPTERTY_REST_PORT = "ARE.webservice.port.REST";
 
     private static final String ARE_HOT_KEY_START_MODEL = "ARE.hotKey.startModel";
     private static final String ARE_HOT_KEY_PAUSE_MODEL = "ARE.hotKey.pauseModel";
@@ -167,12 +165,10 @@ public class NativeHookServices implements NativeKeyListener {
     private void storeDefaultProperties() {
         AREProperties props = AREProperties.instance;
 
-        props.setDefaultPropertyValue(ARE_HOT_KEY_START_MODEL, "VC_F5");
-        props.setDefaultPropertyValue(ARE_HOT_KEY_PAUSE_MODEL, "VC_F6");
-        props.setDefaultPropertyValue(ARE_HOT_KEY_STOP_MODEL, "VC_F7");
-        props.setDefaultPropertyValue(ARE_HOT_KEY_EDIT_MODEL, "VC_F8");
-
-        props.storeProperties();
+        props.setDefaultPropertyValue(ARE_HOT_KEY_START_MODEL, "VC_F5","Hotkey to start model");
+        props.setDefaultPropertyValue(ARE_HOT_KEY_PAUSE_MODEL, "VC_F6","Hotkey to pause model");
+        props.setDefaultPropertyValue(ARE_HOT_KEY_STOP_MODEL, "VC_F7","Hotkey to stop model");
+        props.setDefaultPropertyValue(ARE_HOT_KEY_EDIT_MODEL, "VC_F8","Hotkey to edit model");
     }
 
     public static NativeHookServices getInstance() {
@@ -234,13 +230,7 @@ public class NativeHookServices implements NativeKeyListener {
                 logger.log(Level.WARNING, "error stop model by F-key", e);
             }
         } else if (nke.getKeyCode() == keyCodeEditModel) {
-            try {
-                String webACSPath = "webapps/WebACS/index.html?autoConnect=true&autoDownloadModel=true";
-                String url = MessageFormat.format("http://localhost:{0}/{1}", getCurrentRestPort(), webACSPath);
-                OSUtils.openURL(url, OSUtils.OS_NAMES.ALL);
-            } catch (IOException e) {
-                logger.log(Level.WARNING, "error opening WebACS for current model by F-key.", e);
-            }
+                AREServices.instance.editModel();
         }
     }
 
@@ -248,13 +238,5 @@ public class NativeHookServices implements NativeKeyListener {
     public void nativeKeyTyped(NativeKeyEvent nke) {
         // TODO Auto-generated method stub
         // System.out.println("Native key typed: "+nke);
-    }
-
-    private String getCurrentRestPort() {
-        String port = AREProperties.instance.getProperty(PROPTERTY_REST_PORT);
-        if(port == null || port.isEmpty()) {
-            port = DEFAULT_REST_PORT;
-        }
-        return port;
     }
 }

--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/serverUtils/ServerRepository.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/serverUtils/ServerRepository.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.logging.Level;
 
 import eu.asterics.mw.are.AREProperties;
+import static eu.asterics.mw.are.AREProperties.*;
 import eu.asterics.mw.services.AstericsErrorHandling;
 
 /**
@@ -43,14 +44,14 @@ public class ServerRepository {
     private static ServerRepository instance;
 
     // Rest Server configuration
-    public static final String ARE_WEBSERVICE_PORT_REST_KEY = "ARE.webservice.port.REST";
+    
     public static final String PATH_REST = "/rest";
     public static final int DEFAULT_PORT_REST = 8081;
 
     // Web Socket Server configuration
     public static final String PATH_WEBSOCKET = "/ws";
     public static final String PATH_WEBSOCKET_ASTERICS_DATA = "/astericsData";
-    public static final String ARE_WEBSERVICE_PORT_WEBSOCKET_KEY = "ARE.webservice.port.websocket";
+
     public static final int DEFAULT_PORT_WEBSOCKET = 8082;
 
     // member variables holding property values
@@ -63,14 +64,16 @@ public class ServerRepository {
     private ServerRepository() {
         // init ports and paths with property values
         try {
-            portREST = Integer.parseInt(AREProperties.instance.getProperty(ARE_WEBSERVICE_PORT_REST_KEY, String.valueOf(DEFAULT_PORT_REST)));
+            AREProperties.instance.setDefaultPropertyValue(ARE_WEBSERVICE_PORT_REST_KEY, String.valueOf(DEFAULT_PORT_REST), "The port to use for the REST API.");
+            portREST = Integer.parseInt(AREProperties.instance.getProperty(ARE_WEBSERVICE_PORT_REST_KEY));
         } catch (NumberFormatException e) {
             AstericsErrorHandling.instance.getLogger().logp(Level.WARNING, this.getClass().getName(), "ServerRepository()",
                     "Configured port for REST service invalid: " + e.getMessage(), e);
         }
         // init ports and paths with property values
         try {
-            portWebsocket = Integer.parseInt(AREProperties.instance.getProperty(ARE_WEBSERVICE_PORT_WEBSOCKET_KEY, String.valueOf(DEFAULT_PORT_WEBSOCKET)));
+            AREProperties.instance.setDefaultPropertyValue(ARE_WEBSERVICE_PORT_WEBSOCKET_KEY, String.valueOf(DEFAULT_PORT_WEBSOCKET), "The port to use for websocket communication.");
+            portWebsocket = Integer.parseInt(AREProperties.instance.getProperty(ARE_WEBSERVICE_PORT_WEBSOCKET_KEY));
         } catch (NumberFormatException e) {
             AstericsErrorHandling.instance.getLogger().logp(Level.WARNING, this.getClass().getName(), "ServerRepository()",
                     "Configured port for Websocket service invalid: " + e.getMessage(), e);


### PR DESCRIPTION
This PR improves the AREProperties class:
* Enforce usage of property default values and a property comment by the method setDefaultPropertyValue
 * Use LinkedHashMap for propertyComments to preserve insertion order and use that order for writing the properties to the file areProperties.
 * Updated all currently existing property keys to use setDefaultPropertyValue.

The result is an areProperties file with a nicely formatted content:
```
# ARE properties, generated at Tue Apr 09 20:47:38 CEST 2019

# Enables/Disables ASAPI port registration for ACS. 1=ACS may connect to ARE through the port specified with the key 'ASAPI.ACSPortNumber'. 0=ACS may not connect to the ARE.
ASAPI.enableACSPortConnection=1

# Enables/Disables ARE autodetection by the ACS. 1=Autodetection enabled, 0=Autodetection disabled
ASAPI.enableAREAutoDetection=1

# Sets the ASAPI port number which is used by the ACS to connect to the ARE.
ASAPI.ACSPortNumber=9090

# Default Linux command to start a browser.
ARE.openURL.cmd.linux=xdg-open

# Default Windows command to start a browser.
ARE.openURL.cmd.windows=explorer

# Default Mac OSX command to start a browser.
ARE.openURL.cmd.macosx=open

# The default font size for the ARE GUI.
ARE.gui.font.size=18

# The background colour of the ARE desktop. Please change the value in the ARE GUI.
background_color=-11435361

# Flag to turn off showing the error dialog. 1=show errors, 0=don't show errors
showErrorDialogs=1

# Enable/Disable if bundles should be tested for being installable on this platform via OSGI
ARE.generate.caches.from.installable.bundles=false

# Hotkey to start model
ARE.hotKey.startModel=VC_F5

# Hotkey to pause model
ARE.hotKey.pauseModel=VC_F6

# Hotkey to stop model
ARE.hotKey.stopModel=VC_F7

# Hotkey to edit model
ARE.hotKey.editModel=VC_F8

# If true the CIM port scanning is performed at start of ARE
CIM.scan.at.start=true

# If true the CIMPortManager starts in raw mode, where COM connections can be used directly without CIM protocol
CIM.mode.raw=false

# The port to use for the REST API.
ARE.webservice.port.REST=8081

# The port to use for websocket communication.
ARE.webservice.port.websocket=8082

# Origins that are allowed to access the ARE REST API. Separate with comma (',').
ARE.REST.allowed.origins=localhost,127.0.0.1,asterics.github.io,asterics-foundation.org

# This timeout in [ms] is used to start/stop a model and do other tasks related to models. If you get a timeout during ARE/model start try to increase the value. Especially on a Raspberry Pi this can be necessary.
ThreadPoolTasks.submitTimeout=20000
```
The PR is based on #305 as it is related to the new asterics-docs webpage and new URLs for the AsTeRICS help and WebACS.
As a next step I will create a PR to change the URLs for model editing and help according to https://openproject.studyathome.technikum-wien.at/projects/asterics-docs/work_packages/93/activity