### PR TITLE
Fix ARE window size and font rendering

### DIFF
--- a/ARE/components/actuator.arewindow/src/main/java/eu/asterics/component/actuator/arewindow/AREWindowInstance.java
+++ b/ARE/components/actuator.arewindow/src/main/java/eu/asterics/component/actuator/arewindow/AREWindowInstance.java
@@ -26,6 +26,7 @@
 
 package eu.asterics.component.actuator.arewindow;
 
+import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Point;
 
@@ -265,9 +266,9 @@ public class AREWindowInstance extends AbstractRuntimeComponentInstance {
         public void receiveEvent(final String data) {
             Point pos = AREServices.instance.getAREWindowPosition();
             Point dim = AREServices.instance.getAREWindowDimension();
-            Point screen = AREServices.instance.getScreenDimension();
+            Dimension screen = AREServices.instance.getScreenDimension();
 
-            pos.y = screen.y - dim.y + propYPos;
+            pos.y = screen.height - dim.y + propYPos;
             AREServices.instance.setAREWindowPosition(pos.x + propXPos, pos.y);
         }
     };
@@ -284,9 +285,9 @@ public class AREWindowInstance extends AbstractRuntimeComponentInstance {
         public void receiveEvent(final String data) {
             Point pos = AREServices.instance.getAREWindowPosition();
             Point dim = AREServices.instance.getAREWindowDimension();
-            Point screen = AREServices.instance.getScreenDimension();
+            Dimension screen = AREServices.instance.getScreenDimension();
 
-            pos.x = screen.x - dim.x + propXPos;
+            pos.x = screen.width - dim.x + propXPos;
             AREServices.instance.setAREWindowPosition(pos.x, pos.y + propYPos);
         }
     };
@@ -295,10 +296,10 @@ public class AREWindowInstance extends AbstractRuntimeComponentInstance {
         public void receiveEvent(final String data) {
             Point pos = AREServices.instance.getAREWindowPosition();
             Point dim = AREServices.instance.getAREWindowDimension();
-            Point screen = AREServices.instance.getScreenDimension();
+            Dimension screen = AREServices.instance.getScreenDimension();
 
-            pos.x = screen.x / 2 - dim.x / 2 + propXPos;
-            pos.y = screen.y / 2 - dim.y / 2 + propYPos;
+            pos.x = screen.width / 2 - dim.x / 2 + propXPos;
+            pos.y = screen.height / 2 - dim.y / 2 + propYPos;
             AREServices.instance.setAREWindowPosition(pos.x, pos.y);
         }
     };

--- a/ARE/components/actuator.arewindow/src/main/java/eu/asterics/component/actuator/arewindow/AREWindowInstance.java
+++ b/ARE/components/actuator.arewindow/src/main/java/eu/asterics/component/actuator/arewindow/AREWindowInstance.java
@@ -265,10 +265,10 @@ public class AREWindowInstance extends AbstractRuntimeComponentInstance {
         @Override
         public void receiveEvent(final String data) {
             Point pos = AREServices.instance.getAREWindowPosition();
-            Point dim = AREServices.instance.getAREWindowDimension();
+            Dimension dim = AREServices.instance.getAREWindowDimension();
             Dimension screen = AREServices.instance.getScreenDimension();
 
-            pos.y = screen.height - dim.y + propYPos;
+            pos.y = screen.height - dim.height + propYPos;
             AREServices.instance.setAREWindowPosition(pos.x + propXPos, pos.y);
         }
     };
@@ -284,10 +284,10 @@ public class AREWindowInstance extends AbstractRuntimeComponentInstance {
         @Override
         public void receiveEvent(final String data) {
             Point pos = AREServices.instance.getAREWindowPosition();
-            Point dim = AREServices.instance.getAREWindowDimension();
+            Dimension dim = AREServices.instance.getAREWindowDimension();
             Dimension screen = AREServices.instance.getScreenDimension();
 
-            pos.x = screen.width - dim.x + propXPos;
+            pos.x = screen.width - dim.width + propXPos;
             AREServices.instance.setAREWindowPosition(pos.x, pos.y + propYPos);
         }
     };
@@ -295,11 +295,11 @@ public class AREWindowInstance extends AbstractRuntimeComponentInstance {
         @Override
         public void receiveEvent(final String data) {
             Point pos = AREServices.instance.getAREWindowPosition();
-            Point dim = AREServices.instance.getAREWindowDimension();
+            Dimension dim = AREServices.instance.getAREWindowDimension();
             Dimension screen = AREServices.instance.getScreenDimension();
 
-            pos.x = screen.width / 2 - dim.x / 2 + propXPos;
-            pos.y = screen.height / 2 - dim.y / 2 + propYPos;
+            pos.x = screen.width / 2 - dim.width / 2 + propXPos;
+            pos.y = screen.height / 2 - dim.height / 2 + propYPos;
             AREServices.instance.setAREWindowPosition(pos.x, pos.y);
         }
     };
@@ -319,10 +319,7 @@ public class AREWindowInstance extends AbstractRuntimeComponentInstance {
     final IRuntimeEventListenerPort elpBringToFront = new IRuntimeEventListenerPort() {
         @Override
         public void receiveEvent(final String data) {
-            AREServices.instance.setAREWindowState(Frame.ICONIFIED);
-            AREServices.instance.setAREWindowState(Frame.NORMAL);
-
-            // AREServices.instance.setAREWindowToFront();
+            AREServices.instance.setAREWindowToFront();
         }
     };
 

--- a/ARE/components/actuator.crosshaircursorcontrol/src/main/java/eu/asterics/component/actuator/crosshaircursorcontrol/CrosshairCursorControlInstance.java
+++ b/ARE/components/actuator.crosshaircursorcontrol/src/main/java/eu/asterics/component/actuator/crosshaircursorcontrol/CrosshairCursorControlInstance.java
@@ -35,6 +35,7 @@ import eu.asterics.mw.model.runtime.*;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeEventTriggererPort;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeInputPort;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeOutputPort;
+import eu.asterics.mw.services.AREServices;
 import eu.asterics.mw.services.AstericsThreadPool;
 
 /**
@@ -554,13 +555,7 @@ public class CrosshairCursorControlInstance extends AbstractRuntimeComponentInst
      */
     @Override
     public void start() {
-
-        GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
-        int width = gd.getDisplayMode().getWidth();
-        int height = gd.getDisplayMode().getHeight();
-        Dimension screenSize = new Dimension(width, height);
-
-        // Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        Dimension screenSize = AREServices.instance.getScreenDimension();
         screenWidth = (int) screenSize.getWidth();
         screenHeight = (int) screenSize.getHeight();
         // System.out.println("Screen width:" + screenWidth + " height:" + screenHeight);

--- a/ARE/components/actuator.mouse/src/main/java/eu/asterics/component/actuator/mouse/MouseInstance.java
+++ b/ARE/components/actuator.mouse/src/main/java/eu/asterics/component/actuator/mouse/MouseInstance.java
@@ -44,6 +44,7 @@ import eu.asterics.mw.model.runtime.IRuntimeInputPort;
 import eu.asterics.mw.model.runtime.IRuntimeOutputPort;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeInputPort;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeOutputPort;
+import eu.asterics.mw.services.AREServices;
 
 /**
  * Implements the Mouse plugin, which controls the local mouse using the Java
@@ -284,6 +285,8 @@ public class MouseInstance extends AbstractRuntimeComponentInstance {
 
             propXMax = Integer.parseInt(newValue.toString());
             if (propXMax == 0) {
+                //On Linux the Toolkit returns the virtual screen size, should we use that one for max, or change to 
+                //the screensize of the primary display? --> AREServices.instance.getScreenDimension();
                 Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
                 propXMax = screenSize.width;
             }
@@ -298,6 +301,8 @@ public class MouseInstance extends AbstractRuntimeComponentInstance {
             final Object oldValue = propYMax;
             propYMax = Integer.parseInt(newValue.toString());
             if (propYMax == 0) {
+                //On Linux the Toolkit returns the virtual screen size, should we use that one for max, or change to 
+                //the screensize of the primary display? --> AREServices.instance.getScreenDimension();
                 Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
                 propYMax = screenSize.height;
             }

--- a/ARE/components/actuator.remotewindow/src/main/java/eu/asterics/component/actuator/remotewindow/RemoteWindowInstance.java
+++ b/ARE/components/actuator.remotewindow/src/main/java/eu/asterics/component/actuator/remotewindow/RemoteWindowInstance.java
@@ -26,6 +26,7 @@
 
 package eu.asterics.component.actuator.remotewindow;
 
+import java.awt.Dimension;
 import java.awt.Point;
 
 import com.sun.jna.Native;
@@ -307,8 +308,8 @@ public class RemoteWindowInstance extends AbstractRuntimeComponentInstance {
         if (result != 0) {
             int xPos = rect[0] + propXPos;
             int height = rect[3] - rect[1];
-            Point screen = AREServices.instance.getScreenDimension();
-            int yPos = screen.y - height + propYPos;
+            Dimension screen = AREServices.instance.getScreenDimension();
+            int yPos = screen.height - height + propYPos;
             User32.INSTANCE.SetWindowPos(hWnd, null, xPos, yPos, 0, 0, User32.SWP_NOSIZE);
         }
     }
@@ -329,8 +330,8 @@ public class RemoteWindowInstance extends AbstractRuntimeComponentInstance {
         if (result != 0) {
             int yPos = rect[1] + propYPos;
             int width = rect[2] - rect[0];
-            Point screen = AREServices.instance.getScreenDimension();
-            int xPos = screen.x - width + propXPos;
+            Dimension screen = AREServices.instance.getScreenDimension();
+            int xPos = screen.width - width + propXPos;
             User32.INSTANCE.SetWindowPos(hWnd, null, xPos, yPos, 0, 0, User32.SWP_NOSIZE);
         }
     }
@@ -341,9 +342,9 @@ public class RemoteWindowInstance extends AbstractRuntimeComponentInstance {
         if (result != 0) {
             int width = rect[2] - rect[0];
             int height = rect[3] - rect[1];
-            Point screen = AREServices.instance.getScreenDimension();
-            int xPos = screen.x / 2 - width / 2 + propXPos;
-            int yPos = screen.y / 2 - height / 2 + propYPos;
+            Dimension screen = AREServices.instance.getScreenDimension();
+            int xPos = screen.width / 2 - width / 2 + propXPos;
+            int yPos = screen.height / 2 - height / 2 + propYPos;
             User32.INSTANCE.SetWindowPos(hWnd, null, xPos, yPos, 0, 0, User32.SWP_NOSIZE);
         }
     }

--- a/ARE/components/actuator.textdisplay/src/main/java/eu/asterics/component/actuator/textdisplay/GUI.java
+++ b/ARE/components/actuator.textdisplay/src/main/java/eu/asterics/component/actuator/textdisplay/GUI.java
@@ -43,6 +43,7 @@ import javax.swing.SwingConstants;
 import javax.swing.border.TitledBorder;
 
 import eu.asterics.mw.model.runtime.IRuntimeEventTriggererPort;
+import eu.asterics.mw.services.AREServices;
 
 /**
  * Implements the Graphical User Interface for the Text Display plugin
@@ -57,8 +58,6 @@ public class GUI extends JPanel {
     private JLabel textLabel = null;
 
     // private final double verticalOffset=1;
-    private final float fontSizeMax = 150;
-    private final float fontIncrementStep = 0.5f;
 
     private final TextDisplayInstance owner;
     final IRuntimeEventTriggererPort etpClicked;
@@ -129,38 +128,13 @@ public class GUI extends JPanel {
         textLabel.setPreferredSize(labelDimension);
         textLabel.setMinimumSize(labelDimension);
         textLabel.setMaximumSize(labelDimension);
-
-        String testString = "THIS IS TEST STRING";
-
-        float fontSize = 0;
-        boolean finish = false;
-
-        do {
-            fontSize = fontSize + fontIncrementStep;
-
-            Font font = textLabel.getFont();
-            font = font.deriveFont(fontSize);
-            FontMetrics fontMetrics = textLabel.getFontMetrics(font);
-            Rectangle2D tmpFontSize = fontMetrics.getStringBounds(testString, textLabel.getGraphics());
-
-            double fontHeight = tmpFontSize.getHeight();
-            // double fontWidth=tmpFontSize.getWidth();
-
-            if (fontHeight >= labelHeight) {
-                finish = true;
-                fontSize = fontSize - 1;
-            } else {
-
-                if (fontSize > fontSizeMax) {
-                    finish = true;
-                }
-            }
-        } while (!finish);
-
+   
         textLabel.setOpaque(true);
         textLabel.setForeground(getColorProperty(owner.getTextColor()));
         textLabel.setBackground(getColorProperty(owner.getBackgroundColor()));
 
+        String testString = owner.getDefaultText()!= "" ? owner.getDefaultText() : "THIS IS TEST STRING";
+        float fontSize=AREServices.instance.calcMaxFontSize(textLabel, labelDimension, testString);
         Font font = textLabel.getFont();
         font = font.deriveFont(fontSize);
         textLabel.setFont(font);

--- a/ARE/components/sensor.cellboard/src/main/java/eu/asterics/component/sensor/cellboard/GUICell.java
+++ b/ARE/components/sensor.cellboard/src/main/java/eu/asterics/component/sensor/cellboard/GUICell.java
@@ -339,6 +339,9 @@ public class GUICell extends JPanel implements Accessible {
             g.setFont(font);
             FontMetrics fm = g.getFontMetrics(font);
             int ascent = fm.getMaxAscent();
+            ((Graphics2D)g).setRenderingHint(
+                    RenderingHints.KEY_TEXT_ANTIALIASING,
+                    RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 
             g.setColor(getColorProperty(owner.getTextColor()));
             g.drawString(text, (int) positionX, (int) positionY + ascent);

--- a/ARE/components/sensor.editbox/src/main/java/eu/asterics/component/sensor/editbox/GUI.java
+++ b/ARE/components/sensor.editbox/src/main/java/eu/asterics/component/sensor/editbox/GUI.java
@@ -43,6 +43,8 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
 
+import eu.asterics.mw.services.AREServices;
+
 /**
  * Implements the Graphical User Interface for the Edit Box plugin
  * 
@@ -60,8 +62,6 @@ public class GUI extends JPanel implements FocusListener {
     private final EditBoxInstance owner;
 
     // private final double verticalOffset=1;
-    private final float fontSizeMax = 150;
-    private final float fontIncrementStep = 0.5f;
     private final EditBoxInstance.OutputPort opOutput;
 
     private final int selectText = 1;
@@ -126,32 +126,8 @@ public class GUI extends JPanel implements FocusListener {
         textField.setMinimumSize(labelDimension);
         textField.setMaximumSize(labelDimension);
 
-        String testString = "THIS IS TEST STRING";
-
-        float fontSize = 0;
-        boolean finish = false;
-
-        do {
-            fontSize = fontSize + fontIncrementStep;
-
-            Font font = textField.getFont();
-            font = font.deriveFont(fontSize);
-            FontMetrics fontMetrics = textField.getFontMetrics(font);
-            Rectangle2D tmpFontSize = fontMetrics.getStringBounds(testString, textField.getGraphics());
-
-            double fontHeight = tmpFontSize.getHeight();
-            // double fontWidth=tmpFontSize.getWidth();
-
-            if (fontHeight >= labelHeight) {
-                finish = true;
-                fontSize = fontSize - 1;
-            } else {
-
-                if (fontSize > fontSizeMax) {
-                    finish = true;
-                }
-            }
-        } while (!finish);
+        String testString = owner.getDefaultText()!= "" ? owner.getDefaultText() : "THIS IS TEST STRING";
+        float fontSize=AREServices.instance.calcMaxFontSize(textField, labelDimension, testString);
 
         textField.setOpaque(true);
         textField.setForeground(getColorProperty(owner.getTextColor()));

--- a/ARE/components/sensor.eyetracker/src/main/java/eu/asterics/component/sensor/eyetracker/EyetrackerInstance.java
+++ b/ARE/components/sensor.eyetracker/src/main/java/eu/asterics/component/sensor/eyetracker/EyetrackerInstance.java
@@ -258,7 +258,7 @@ public class EyetrackerInstance extends AbstractRuntimeComponentInstance {
 
             propXMax = Integer.parseInt(newValue.toString());
             if (propXMax == 0) {
-                Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+                Dimension screenSize = AREServices.instance.getScreenDimension();
                 propXMax = screenSize.width;
             }
             calib.updateCalibParams(propXMin, propXMax, propYMin, propYMax, propCalibColumns, propCalibRows);
@@ -272,7 +272,7 @@ public class EyetrackerInstance extends AbstractRuntimeComponentInstance {
             final Object oldValue = propYMax;
             propYMax = Integer.parseInt(newValue.toString());
             if (propYMax == 0) {
-                Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+                Dimension screenSize = AREServices.instance.getScreenDimension();
                 propYMax = screenSize.height;
             }
             calib.updateCalibParams(propXMin, propXMax, propYMin, propYMax, propCalibColumns, propCalibRows);

--- a/ARE/components/sensor.eyetracker/src/main/java/eu/asterics/component/sensor/eyetracker/POSIT.java
+++ b/ARE/components/sensor.eyetracker/src/main/java/eu/asterics/component/sensor/eyetracker/POSIT.java
@@ -41,6 +41,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import eu.asterics.component.sensor.eyetracker.jni.BridgePOSIT;
+import eu.asterics.mw.services.AREServices;
 import eu.asterics.mw.services.AstericsErrorHandling;
 
 public class POSIT {
@@ -147,7 +148,7 @@ public class POSIT {
     protected synchronized void startEvaluation() {
         sendEyeCoordinates = 1;
         int errormsg;
-        Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
+        Dimension screenResolution = AREServices.instance.getScreenDimension();
         errormsg = bridgePOSIT.startEval(screenResolution.width, screenResolution.height);
         if (errormsg != 1) {
             AstericsErrorHandling.instance.reportInfo(this.owner,

--- a/ARE/components/sensor.eyetribe/src/main/java/eu/asterics/component/sensor/eyetribe/CalibrationGenerator.java
+++ b/ARE/components/sensor.eyetribe/src/main/java/eu/asterics/component/sensor/eyetribe/CalibrationGenerator.java
@@ -46,6 +46,7 @@ import javax.sound.sampled.UnsupportedAudioFileException;
 
 import com.theeyetribe.client.GazeManager;
 
+import eu.asterics.mw.services.AREServices;
 import eu.asterics.mw.services.AstericsThreadPool;
 
 /**
@@ -78,8 +79,8 @@ public class CalibrationGenerator implements Runnable {
 
         // Class constructor
         public calibPoint(int i) {
-            int width = Toolkit.getDefaultToolkit().getScreenSize().width;
-            int height = Toolkit.getDefaultToolkit().getScreenSize().height;
+            int width = AREServices.instance.getScreenDimension().width;
+            int height = AREServices.instance.getScreenDimension().height;
             xLocation = width / 2 * (i % 3);
             yLocation = height / 2 * (int) (i / 3);
 

--- a/ARE/components/sensor.eyex/src/main/java/eu/asterics/component/sensor/eyex/CalibrationGenerator.java
+++ b/ARE/components/sensor.eyex/src/main/java/eu/asterics/component/sensor/eyex/CalibrationGenerator.java
@@ -44,6 +44,7 @@ import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.SourceDataLine;
 import javax.sound.sampled.UnsupportedAudioFileException;
 
+import eu.asterics.mw.services.AREServices;
 import eu.asterics.mw.services.AstericsThreadPool;
 
 /**
@@ -76,8 +77,8 @@ public class CalibrationGenerator implements Runnable {
 
         // Class constructor
         public calibPoint(int i) {
-            int width = Toolkit.getDefaultToolkit().getScreenSize().width;
-            int height = Toolkit.getDefaultToolkit().getScreenSize().height;
+            int width = AREServices.instance.getScreenDimension().width;
+            int height = AREServices.instance.getScreenDimension().height;
             xLocation = width / 2 * (i % 3);
             yLocation = height / 2 * (int) (i / 3);
 

--- a/ARE/components/sensor.slider/src/main/java/eu/asterics/component/sensor/slider/GUI.java
+++ b/ARE/components/sensor.slider/src/main/java/eu/asterics/component/sensor/slider/GUI.java
@@ -79,7 +79,7 @@ public class GUI extends JPanel implements ChangeListener {
      * @param height
      */
     private void design(int width, int height) {
-        Font actFont = new Font("Arial", 0, owner.propFontSize);
+        Font actFont = new Font("Arial", 0, Math.min(owner.propFontSize,AREServices.instance.getMaxFontSize()));
 
         // Create Panels
         sliderPanel = new JPanel(new BorderLayout());
@@ -111,7 +111,6 @@ public class GUI extends JPanel implements ChangeListener {
         slider.addChangeListener(this);
         slider.setFont(actFont);
         sliderPanel.add(slider, BorderLayout.CENTER);
-        AREServices.instance.adjustFonts(sliderPanel, 24, 6, 0);
         sliderPanel.setVisible(true);
 
         this.setLayout(new BorderLayout());

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/DeploymentManager.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/DeploymentManager.java
@@ -1263,7 +1263,7 @@ public class DeploymentManager {
         return (gui.getAREWindowLocation());
     }
 
-    public Point getAREWindowDimension() {
+    public Dimension getAREWindowDimension() {
         return (gui.getAREWindowDimension());
     }
 

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/DeploymentManager.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/DeploymentManager.java
@@ -1244,8 +1244,8 @@ public class DeploymentManager {
         IRuntimeModel model = getCurrentRuntimeModel();
         IComponentInstance component = model.getComponentInstance(componentInstanceID);
         AREGUIElement el = component.getAREGUIElement();
-        if (el != null) {
-            Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        if (el != null) {            
+            Dimension screenSize = getScreenDimension();
             int width = (int) (screenSize.width * el.width / 10000f);
             int height = (int) (screenSize.height * el.height / 10000f);
             return new Dimension(width, height);
@@ -1255,7 +1255,7 @@ public class DeploymentManager {
 
     }
 
-    public Point getScreenDimension() {
+    public Dimension getScreenDimension() {
         return (gui.getScreenDimension());
     }
 
@@ -1296,7 +1296,7 @@ public class DeploymentManager {
         AREGUIElement el = component.getAREGUIElement();
 
         if (el != null) {
-            Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+            Dimension screenSize = getScreenDimension();            
             gui.getDesktop();
             // int x = ((screenSize.width*el.posX/100) +
             // desktop.getLocationOnScreen().x);

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/DeploymentManager.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/DeploymentManager.java
@@ -1,6 +1,7 @@
 package eu.asterics.mw.are;
 
 import java.awt.Dimension;
+import java.awt.Font;
 import java.awt.Point;
 import java.awt.Toolkit;
 import java.io.PrintWriter;
@@ -16,6 +17,7 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.logging.Logger;
 
+import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -1505,5 +1507,12 @@ public class DeploymentManager {
                 }
             }
         }
+    }
+
+    public float calcMaxFontSize(JComponent component, Dimension widgetDim, String testString) {
+        if(gui!=null) {
+            return gui.calcMaxFontSize(component, widgetDim, testString);
+        }
+        return 15;
     }
 }

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/DeploymentManager.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/DeploymentManager.java
@@ -1513,6 +1513,13 @@ public class DeploymentManager {
         if(gui!=null) {
             return gui.calcMaxFontSize(component, widgetDim, testString);
         }
-        return 15;
+        return AstericsGUI.DEFAULT_FONT_SIZE;
+    }
+
+    public int getMaxFontSize() {
+        if(gui!=null) {
+            return gui.getMaxFontSize();
+        }
+        return AstericsGUI.DEFAULT_FONT_SIZE;
     }
 }

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/Main.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/Main.java
@@ -71,6 +71,9 @@ public class Main implements BundleActivator {
     @Override
     public void start(final BundleContext context) throws Exception {
         logger = AstericsErrorHandling.instance.getLogger();
+        
+        System.setProperty("awt.useSystemAAFontSettings","on");
+        System.setProperty("swing.aatext", "true");
 
         // set default uncaught exception handler to get logged messages in case of exception.
         Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler() {

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsDesktop.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsDesktop.java
@@ -26,6 +26,7 @@
 package eu.asterics.mw.gui;
 
 import java.awt.Dimension;
+import java.awt.Point;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -44,7 +45,6 @@ import eu.asterics.mw.are.AREProperties;
  *
  */
 public class AstericsDesktop extends JPanel implements ActionListener, MouseMotionListener {
-    private Dimension screenSize;
     AstericsGUI parentFrame;
 
     // HashMap areOptions;
@@ -58,8 +58,8 @@ public class AstericsDesktop extends JPanel implements ActionListener, MouseMoti
         } else {
         }
 
-        screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-        setPreferredSize(new Dimension(screenSize.width, screenSize.height));
+        Point p=frame.getScreenDimension();
+        setPreferredSize(new Dimension(p.x, p.y));
         // setBorder(BorderFactory.createTitledBorder(
         // "Desktop"));
         addMouseMotionListener(this);

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsDesktop.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsDesktop.java
@@ -57,9 +57,8 @@ public class AstericsDesktop extends JPanel implements ActionListener, MouseMoti
         if (props.checkProperty("fullscreen", "1")) {
         } else {
         }
-
-        Point p=frame.getScreenDimension();
-        setPreferredSize(new Dimension(p.x, p.y));
+        
+        setPreferredSize(frame.getScreenDimension());
         // setBorder(BorderFactory.createTitledBorder(
         // "Desktop"));
         addMouseMotionListener(this);

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
@@ -105,7 +105,6 @@ public class AstericsGUI implements IAREEventListener {
     private Container pane;
 
     private final AsapiSupport as;
-    Dimension screenSize;
     private JFrame mainFrame;
     OptionsFrame optionsFrame;
     // private AboutFrame aboutFrame;
@@ -120,7 +119,7 @@ public class AstericsGUI implements IAREEventListener {
 
     public AstericsGUI(BundleContext bundleContext) {
         super();
-
+        
         AREProperties.instance.setDefaultPropertyValue(DEFAULT_FONT_SIZE_PROPERTY, String.valueOf(DEFAULT_FONT_SIZE), "The default font size for the ARE GUI.");
         Integer fontSize = DEFAULT_FONT_SIZE;
         try {
@@ -133,48 +132,47 @@ public class AstericsGUI implements IAREEventListener {
         AstericsErrorHandling.instance.getLogger().info(DEFAULT_FONT_SIZE_PROPERTY + "=" + fontSize);
         AREProperties.instance.setProperty(DEFAULT_FONT_SIZE_PROPERTY, Integer.toString(fontSize));
 
-        UIManager.getLookAndFeelDefaults().put("defaultFont", new Font("Arial", Font.PLAIN, fontSize));
+        Font customFont=new Font("Arial", Font.PLAIN, fontSize);
+        UIManager.getLookAndFeelDefaults().put("defaultFont", customFont);
 
         UIManager.get("messageFont");
-        UIManager.put("OptionPane.messageFont", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("OptionPane.messageFont", customFont);
 
         UIManager.get("messageForeground");
         UIManager.put("OptionPane.messageForeground", Color.black);
 
-        UIManager.put("Button.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("ToggleButton.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("RadioButton.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("CheckBox.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("ColorChooser.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("ComboBox.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("Label.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("List.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("MenuBar.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("MenuItem.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("RadioButtonMenuItem.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("CheckBoxMenuItem.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("Menu.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("PopupMenu.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("OptionPane.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("Panel.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("ProgressBar.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("ScrollPane.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("Viewport.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("TabbedPane.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("Table.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("TableHeader.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("TextField.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("PasswordField.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("TextArea.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("TextPane.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("EditorPane.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("TitledBorder.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("ToolBar.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("ToolTip.font", new Font("Arial", Font.PLAIN, fontSize));
-        UIManager.put("Tree.font", new Font("Arial", Font.PLAIN, fontSize));
+        UIManager.put("Button.font", customFont);
+        UIManager.put("ToggleButton.font", customFont);
+        UIManager.put("RadioButton.font", customFont);
+        UIManager.put("CheckBox.font", customFont);
+        UIManager.put("ColorChooser.font", customFont);
+        UIManager.put("ComboBox.font", customFont);
+        UIManager.put("Label.font", customFont);
+        UIManager.put("List.font", customFont);
+        UIManager.put("MenuBar.font", customFont);
+        UIManager.put("MenuItem.font", customFont);
+        UIManager.put("RadioButtonMenuItem.font", customFont);
+        UIManager.put("CheckBoxMenuItem.font", customFont);
+        UIManager.put("Menu.font", customFont);
+        UIManager.put("PopupMenu.font", customFont);
+        UIManager.put("OptionPane.font", customFont);
+        UIManager.put("Panel.font", customFont);
+        UIManager.put("ProgressBar.font", customFont);
+        UIManager.put("ScrollPane.font", customFont);
+        UIManager.put("Viewport.font", customFont);
+        UIManager.put("TabbedPane.font", customFont);
+        UIManager.put("Table.font", customFont);
+        UIManager.put("TableHeader.font", customFont);
+        UIManager.put("TextField.font", customFont);
+        UIManager.put("PasswordField.font", customFont);
+        UIManager.put("TextArea.font", customFont);
+        UIManager.put("TextPane.font", customFont);
+        UIManager.put("EditorPane.font", customFont);
+        UIManager.put("TitledBorder.font", customFont);
+        UIManager.put("ToolBar.font", customFont);
+        UIManager.put("ToolTip.font", customFont);
+        UIManager.put("Tree.font", customFont);
 
-        // logger = AstericsErrorHandling.instance.getLogger();
-        screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         AREServices.instance.registerAREEventListener(this);
 
         this.bundleContext = bundleContext;
@@ -353,9 +351,10 @@ public class AstericsGUI implements IAREEventListener {
     }
 
     public Point getScreenDimension() {
+        Dimension d=Toolkit.getDefaultToolkit().getScreenSize();
         Point p = new Point();
-        p.x = screenSize.width;
-        p.y = screenSize.height;
+        p.x = d.width;
+        p.y = d.height;
         return (p);
     }
 
@@ -487,8 +486,9 @@ public class AstericsGUI implements IAREEventListener {
             @Override
             public void run() {
 
-                int realX = screenSize.width;
-                int realY = screenSize.height;
+                Point p=getScreenDimension();
+                int realX = p.x;
+                int realY = p.y;
 
                 int nposX = (int) (realX * posX / 10000f);
                 int nposY = (int) (realY * posY / 10000f);
@@ -657,6 +657,8 @@ public class AstericsGUI implements IAREEventListener {
         int decorationPadding = 0;
         int controlPanelPaddingW = 0;
         int controlPanelPaddingH = 0;
+        Point p=getScreenDimension();
+        Dimension screenSize=new Dimension(p.x,p.y);
 
         if (!modelGUIInfo.isDecoration()) {
             // decorationPadding=0;

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
@@ -368,7 +368,10 @@ public class AstericsGUI implements IAREEventListener {
             int width = gd.getDisplayMode().getWidth();
             int height = gd.getDisplayMode().getHeight();
             primaryScreenSize = new Dimension(width, height);
+    
+            AstericsErrorHandling.instance.getLogger().info("Primary Screen Size: " + primaryScreenSize);
         }
+
         return primaryScreenSize;
     }
 

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
@@ -8,6 +8,8 @@ import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Frame;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.awt.MenuItem;
 import java.awt.Point;
@@ -93,6 +95,8 @@ public class AstericsGUI implements IAREEventListener {
     static String ICON_PATH = "/images/icon.gif";
     static String TRAY_ICON_PATH = "/images/tray_icon.gif";
     static String ARE_OPTIONS = ".options";
+    //cache the screen size of the primary monitor.
+    Dimension primaryScreenSize;
 
     public AstericsDesktop desktop;
 
@@ -350,12 +354,15 @@ public class AstericsGUI implements IAREEventListener {
         }
     }
 
-    public Point getScreenDimension() {
-        Dimension d=Toolkit.getDefaultToolkit().getScreenSize();
-        Point p = new Point();
-        p.x = d.width;
-        p.y = d.height;
-        return (p);
+    public Dimension getScreenDimension() {
+        //Dimension d=Toolkit.getDefaultToolkit().getScreenSize();
+        if(primaryScreenSize==null) {
+            GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
+            int width = gd.getDisplayMode().getWidth();
+            int height = gd.getDisplayMode().getHeight();
+            primaryScreenSize = new Dimension(width, height);
+        }
+        return primaryScreenSize;
     }
 
     public Point getAREWindowDimension() {
@@ -486,9 +493,9 @@ public class AstericsGUI implements IAREEventListener {
             @Override
             public void run() {
 
-                Point p=getScreenDimension();
-                int realX = p.x;
-                int realY = p.y;
+                Dimension screenSize=getScreenDimension();
+                int realX = screenSize.width;
+                int realY = screenSize.height;
 
                 int nposX = (int) (realX * posX / 10000f);
                 int nposY = (int) (realY * posY / 10000f);
@@ -657,8 +664,8 @@ public class AstericsGUI implements IAREEventListener {
         int decorationPadding = 0;
         int controlPanelPaddingW = 0;
         int controlPanelPaddingH = 0;
-        Point p=getScreenDimension();
-        Dimension screenSize=new Dimension(p.x,p.y);
+        
+        Dimension screenSize=getScreenDimension();
 
         if (!modelGUIInfo.isDecoration()) {
             // decorationPadding=0;

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
@@ -78,6 +78,7 @@ import eu.asterics.mw.model.deployment.impl.ModelGUIInfo;
 import eu.asterics.mw.services.AREServices;
 import eu.asterics.mw.services.AstericsErrorHandling;
 import eu.asterics.mw.services.IAREEventListener;
+import eu.asterics.mw.utils.OSUtils;
 
 /**
  * @author Nearchos Paspallis [nearchos@cs.ucy.ac.cy] Konstantinos Kakousis [kakousis@cs.ucy.ac.cy] Chris Veigl [veigl@technikum-wien.at] Date: Aug 20, 2010
@@ -354,9 +355,20 @@ public class AstericsGUI implements IAREEventListener {
         }
     }
 
+    /**
+     * This method returns the screen size to use for layout and size calculations of gui elements and plugins.
+     * In a multi display environment the screen size of the primary device is used.
+     * 
+     * @return
+     */
     public Dimension getScreenDimension() {
+        //When using Toolkit, there are differences between Linux and Windows. On Windows the primary screen size is returned, 
+        //on Linux the virtual screen size (size of all displays) is returned. 
         //Dimension d=Toolkit.getDefaultToolkit().getScreenSize();
+        
         if(primaryScreenSize==null) {
+            //This returns the screen size of the primary display only. But this method invocation is very slow, that's
+            //why we cache the result in primaryScreenSize.
             GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
             int width = gd.getDisplayMode().getWidth();
             int height = gd.getDisplayMode().getHeight();
@@ -365,11 +377,12 @@ public class AstericsGUI implements IAREEventListener {
         return primaryScreenSize;
     }
 
-    public Point getAREWindowDimension() {
-        Point p = new Point();
-        p.x = mainFrame.getWidth();
-        p.y = mainFrame.getHeight();
-        return (p);
+    /**
+     * Returns the current size of the ARE GUI window.
+     * @return
+     */
+    public Dimension getAREWindowDimension() {
+        return mainFrame.getSize();
     }
 
     public Point getAREWindowLocation() {
@@ -388,8 +401,19 @@ public class AstericsGUI implements IAREEventListener {
         mainFrame.setState(state);
     }
 
+    /**
+     * This method brings the ARE window to front.
+     */
     public void setAREWindowToFront() {
-        mainFrame.toFront();
+        //at least on Linux, hopefully also on Mac, the standard approach works.
+        if(!OSUtils.isWindows()) {
+            mainFrame.setVisible(true);
+            mainFrame.toFront();
+        } else {
+            //on Windows, only this trick works
+            mainFrame.setState(Frame.ICONIFIED);
+            mainFrame.setState(Frame.NORMAL);
+        }
         mainFrame.repaint();
     }
 

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
@@ -88,7 +88,7 @@ import eu.asterics.mw.utils.OSUtils;
  *         Time: 2:14:37 PM
  */
 public class AstericsGUI implements IAREEventListener {
-    private final static int DEFAULT_FONT_SIZE = 18;
+    public final static int DEFAULT_FONT_SIZE = 18;
     private static String DEFAULT_FONT_SIZE_PROPERTY = "ARE.gui.font.size";
     public final static String ARE_VERSION = "#{APPLICATION_VERSION_NUMBER}#";
     static int DEFAULT_SCREEN_X = 0;
@@ -99,7 +99,7 @@ public class AstericsGUI implements IAREEventListener {
     static String ICON_PATH = "/images/icon.gif";
     static String TRAY_ICON_PATH = "/images/tray_icon.gif";
     static String ARE_OPTIONS = ".options";
-    //cache the screen size of the primary monitor.
+    // cache the screen size of the primary monitor.
     Dimension primaryScreenSize;
 
     public AstericsDesktop desktop;
@@ -127,20 +127,11 @@ public class AstericsGUI implements IAREEventListener {
 
     public AstericsGUI(BundleContext bundleContext) {
         super();
-        
+
         AREProperties.instance.setDefaultPropertyValue(DEFAULT_FONT_SIZE_PROPERTY, String.valueOf(DEFAULT_FONT_SIZE), "The default font size for the ARE GUI.");
-        Integer fontSize = DEFAULT_FONT_SIZE;
-        try {
-            fontSize = new Integer(AREProperties.instance.getProperty(DEFAULT_FONT_SIZE_PROPERTY));
-        } catch (NumberFormatException e) {
-            AstericsErrorHandling.instance.getLogger().warning("Could not parse numeric fontSize for ARE GUI: key: " + DEFAULT_FONT_SIZE_PROPERTY + "="
-                    + AREProperties.instance.getProperty(DEFAULT_FONT_SIZE_PROPERTY));
-        }
-
-        AstericsErrorHandling.instance.getLogger().info(DEFAULT_FONT_SIZE_PROPERTY + "=" + fontSize);
-        AREProperties.instance.setProperty(DEFAULT_FONT_SIZE_PROPERTY, Integer.toString(fontSize));
-
-        Font customFont=new Font("Arial", Font.PLAIN, fontSize);
+        int fontSize = (int) getMaxFontSize();
+        AstericsErrorHandling.instance.getLogger().info("Using overall fontSize: " + fontSize);
+        Font customFont = new Font("Arial", Font.PLAIN, fontSize);
         UIManager.getLookAndFeelDefaults().put("defaultFont", customFont);
 
         UIManager.get("messageFont");
@@ -149,6 +140,7 @@ public class AstericsGUI implements IAREEventListener {
         UIManager.get("messageForeground");
         UIManager.put("OptionPane.messageForeground", Color.black);
 
+        UIManager.put("Slider.font", customFont);
         UIManager.put("Button.font", customFont);
         UIManager.put("ToggleButton.font", customFont);
         UIManager.put("RadioButton.font", customFont);
@@ -359,19 +351,19 @@ public class AstericsGUI implements IAREEventListener {
     }
 
     /**
-     * This method returns the screen size to use for layout and size calculations of gui elements and plugins.
-     * In a multi display environment the screen size of the primary device is used.
+     * This method returns the screen size to use for layout and size calculations of gui elements and plugins. In a multi display environment the screen size
+     * of the primary device is used.
      * 
      * @return
      */
     public Dimension getScreenDimension() {
-        //When using Toolkit, there are differences between Linux and Windows. On Windows the primary screen size is returned, 
-        //on Linux the virtual screen size (size of all displays) is returned. 
-        //Dimension d=Toolkit.getDefaultToolkit().getScreenSize();
-        
-        if(primaryScreenSize==null) {
-            //This returns the screen size of the primary display only. But this method invocation is very slow, that's
-            //why we cache the result in primaryScreenSize.
+        // When using Toolkit, there are differences between Linux and Windows. On Windows the primary screen size is returned,
+        // on Linux the virtual screen size (size of all displays) is returned.
+        // Dimension d=Toolkit.getDefaultToolkit().getScreenSize();
+
+        if (primaryScreenSize == null) {
+            // This returns the screen size of the primary display only. But this method invocation is very slow, that's
+            // why we cache the result in primaryScreenSize.
             GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
             int width = gd.getDisplayMode().getWidth();
             int height = gd.getDisplayMode().getHeight();
@@ -382,6 +374,7 @@ public class AstericsGUI implements IAREEventListener {
 
     /**
      * Returns the current size of the ARE GUI window.
+     * 
      * @return
      */
     public Dimension getAREWindowDimension() {
@@ -408,12 +401,12 @@ public class AstericsGUI implements IAREEventListener {
      * This method brings the ARE window to front.
      */
     public void setAREWindowToFront() {
-        //at least on Linux, hopefully also on Mac, the standard approach works.
-        if(!OSUtils.isWindows()) {
+        // at least on Linux, hopefully also on Mac, the standard approach works.
+        if (!OSUtils.isWindows()) {
             mainFrame.setVisible(true);
             mainFrame.toFront();
         } else {
-            //on Windows, only this trick works
+            // on Windows, only this trick works
             mainFrame.setState(Frame.ICONIFIED);
             mainFrame.setState(Frame.NORMAL);
         }
@@ -520,7 +513,7 @@ public class AstericsGUI implements IAREEventListener {
             @Override
             public void run() {
 
-                Dimension screenSize=getScreenDimension();
+                Dimension screenSize = getScreenDimension();
                 int realX = screenSize.width;
                 int realY = screenSize.height;
 
@@ -691,8 +684,8 @@ public class AstericsGUI implements IAREEventListener {
         int decorationPadding = 0;
         int controlPanelPaddingW = 0;
         int controlPanelPaddingH = 0;
-        
-        Dimension screenSize=getScreenDimension();
+
+        Dimension screenSize = getScreenDimension();
 
         if (!modelGUIInfo.isDecoration()) {
             // decorationPadding=0;
@@ -887,6 +880,45 @@ public class AstericsGUI implements IAREEventListener {
         controlPane.setEditKeyName(key);
     }
 
+    /**
+     * This method returns the property value for the font size configured in areProperties ({@link AstericsGUI#DEFAULT_FONT_SIZE_PROPERTY}).
+     * @return
+     */
+    private int getFontSizePropertyValue() {
+        Integer fontSize = DEFAULT_FONT_SIZE;
+        try {
+            fontSize = new Integer(AREProperties.instance.getProperty(DEFAULT_FONT_SIZE_PROPERTY));
+        } catch (NumberFormatException e) {
+            AstericsErrorHandling.instance.getLogger().warning("Could not parse numeric fontSize for ARE GUI: key: " + DEFAULT_FONT_SIZE_PROPERTY + "="
+                    + AREProperties.instance.getProperty(DEFAULT_FONT_SIZE_PROPERTY));
+        }
+        return fontSize;
+    }
+
+    /**
+     * This method returns the maximum allowed font size to use for all ARE GUI elements. The maximum font size is dependent on the configured size in
+     * areProperties ({@link AstericsGUI#DEFAULT_FONT_SIZE_PROPERTY}) and overridden in case of a low screen resolution.
+     * 
+     * @return
+     */
+    public int getMaxFontSize() {
+        int tmpFontSize=DEFAULT_FONT_SIZE*2;
+        // Override configured fontSize in case of a low screen resolution
+        if (getScreenDimension().width < 1440 || getScreenDimension().height < 900) {
+            AstericsErrorHandling.instance.getLogger().info("Overriding fontSize because of low screen resolution");
+            tmpFontSize = 10;
+        }
+        return Math.min(getFontSizePropertyValue(), tmpFontSize);
+    }
+
+    /**
+     * This method calculates the maximum font size for the given component and depending on the requested widgetDim dimension and the given testString.
+     * 
+     * @param component
+     * @param widgetDim
+     * @param testString
+     * @return
+     */
     public float calcMaxFontSize(JComponent component, Dimension widgetDim, String testString) {
         float fontSize = 0;
         boolean finish = false;
@@ -902,13 +934,14 @@ public class AstericsGUI implements IAREEventListener {
             Rectangle2D tmpFontSize = fontMetrics.getStringBounds(testString, component.getGraphics());
 
             double fontHeight = tmpFontSize.getHeight();
-            double fontWidth=tmpFontSize.getWidth();
+            double fontWidth = tmpFontSize.getWidth();
 
-            if (fontHeight >= widgetDim.getHeight() || fontWidth >= widgetDim.getWidth()||fontSize > fontSizeMax) {
+            if (fontHeight >= widgetDim.getHeight() || fontWidth >= widgetDim.getWidth() || fontSize > fontSizeMax) {
                 finish = true;
                 fontSize = fontSize - 2;
-            } 
+            }
         } while (!finish);
+
         return fontSize;
     }
 

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
@@ -7,6 +7,7 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.FontMetrics;
 import java.awt.Frame;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
@@ -25,6 +26,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.event.WindowAdapter;
+import java.awt.geom.Rectangle2D;
 import java.io.File;
 import java.net.InetAddress;
 import java.net.URL;
@@ -56,6 +58,7 @@ import java.net.UnknownHostException;
  */
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -882,6 +885,31 @@ public class AstericsGUI implements IAREEventListener {
 
     public void setEditKeyName(String key) {
         controlPane.setEditKeyName(key);
+    }
+
+    public float calcMaxFontSize(JComponent component, Dimension widgetDim, String testString) {
+        float fontSize = 0;
+        boolean finish = false;
+        final float fontSizeMax = 150;
+        final float fontIncrementStep = 0.5f;
+
+        do {
+            fontSize = fontSize + fontIncrementStep;
+
+            Font font = component.getFont();
+            font = font.deriveFont(fontSize);
+            FontMetrics fontMetrics = component.getFontMetrics(font);
+            Rectangle2D tmpFontSize = fontMetrics.getStringBounds(testString, component.getGraphics());
+
+            double fontHeight = tmpFontSize.getHeight();
+            double fontWidth=tmpFontSize.getWidth();
+
+            if (fontHeight >= widgetDim.getHeight() || fontWidth >= widgetDim.getWidth()||fontSize > fontSizeMax) {
+                finish = true;
+                fontSize = fontSize - 2;
+            } 
+        } while (!finish);
+        return fontSize;
     }
 
 }

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/ControlPane.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/ControlPane.java
@@ -176,7 +176,7 @@ public class ControlPane extends JPanel {
         JComponent controlPanel = makeControlPanel("", axis);
         mainPanel = new JPanel();
         mainPanel.setLayout(new BoxLayout(mainPanel, axis));
-        mainPanel.setPreferredSize(new Dimension(CONTROLPANEL_WIDTH, astericsGUI.getScreenDimension().y));
+        mainPanel.setPreferredSize(new Dimension(CONTROLPANEL_WIDTH, astericsGUI.getScreenDimension().height));
         mainPanel.add(controlPanel);
         add(mainPanel);
     }
@@ -552,7 +552,7 @@ public class ControlPane extends JPanel {
 
     public void resizeLabels(int orientation) {
         int newSize = mainFrame.getHeight() / 8;
-        int maxSize = astericsGUI.getScreenDimension().x / 30;
+        int maxSize = astericsGUI.getScreenDimension().width / 30;
 
         if (newSize > maxSize) {
             newSize = maxSize;
@@ -583,9 +583,9 @@ public class ControlPane extends JPanel {
             globeLabel.resizeImage(newSize);
 
             if (orientation == BoxLayout.Y_AXIS) {
-                mainPanel.setPreferredSize(new Dimension(newSize, astericsGUI.getScreenDimension().y));
+                mainPanel.setPreferredSize(new Dimension(newSize, astericsGUI.getScreenDimension().height));
             } else {
-                mainPanel.setPreferredSize(new Dimension(astericsGUI.getScreenDimension().y, newSize));
+                mainPanel.setPreferredSize(new Dimension(astericsGUI.getScreenDimension().height, newSize));
             }
 
             iconPanel.revalidate();

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/ControlPane.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/ControlPane.java
@@ -176,7 +176,7 @@ public class ControlPane extends JPanel {
         JComponent controlPanel = makeControlPanel("", axis);
         mainPanel = new JPanel();
         mainPanel.setLayout(new BoxLayout(mainPanel, axis));
-        mainPanel.setPreferredSize(new Dimension(CONTROLPANEL_WIDTH, astericsGUI.screenSize.height));
+        mainPanel.setPreferredSize(new Dimension(CONTROLPANEL_WIDTH, astericsGUI.getScreenDimension().y));
         mainPanel.add(controlPanel);
         add(mainPanel);
     }
@@ -552,7 +552,7 @@ public class ControlPane extends JPanel {
 
     public void resizeLabels(int orientation) {
         int newSize = mainFrame.getHeight() / 8;
-        int maxSize = astericsGUI.screenSize.width / 30;
+        int maxSize = astericsGUI.getScreenDimension().x / 30;
 
         if (newSize > maxSize) {
             newSize = maxSize;
@@ -583,9 +583,9 @@ public class ControlPane extends JPanel {
             globeLabel.resizeImage(newSize);
 
             if (orientation == BoxLayout.Y_AXIS) {
-                mainPanel.setPreferredSize(new Dimension(newSize, astericsGUI.screenSize.height));
+                mainPanel.setPreferredSize(new Dimension(newSize, astericsGUI.getScreenDimension().y));
             } else {
-                mainPanel.setPreferredSize(new Dimension(astericsGUI.screenSize.height, newSize));
+                mainPanel.setPreferredSize(new Dimension(astericsGUI.getScreenDimension().y, newSize));
             }
 
             iconPanel.revalidate();

--- a/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
@@ -742,7 +742,7 @@ public class AREServices implements IAREServices {
 
     }
 
-    public Point getScreenDimension() {
+    public Dimension getScreenDimension() {
         return DeploymentManager.instance.getScreenDimension();
     }
 

--- a/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
@@ -48,6 +48,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSlider;
@@ -740,6 +741,10 @@ public class AREServices implements IAREServices {
 
         return DeploymentManager.instance.getComponentPosition(componentInstance);
 
+    }
+    
+    public float calcMaxFontSize(JComponent component, Dimension widgetDim, String testString) {
+        return DeploymentManager.instance.calcMaxFontSize(component, widgetDim, testString);
     }
 
     public Dimension getScreenDimension() {

--- a/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
@@ -746,7 +746,7 @@ public class AREServices implements IAREServices {
         return DeploymentManager.instance.getScreenDimension();
     }
 
-    public Point getAREWindowDimension() {
+    public Dimension getAREWindowDimension() {
         return DeploymentManager.instance.getAREWindowDimension();
     }
 

--- a/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
@@ -747,6 +747,10 @@ public class AREServices implements IAREServices {
         return DeploymentManager.instance.calcMaxFontSize(component, widgetDim, testString);
     }
 
+    public int getMaxFontSize() {
+        return DeploymentManager.instance.getMaxFontSize();
+    }
+    
     public Dimension getScreenDimension() {
         return DeploymentManager.instance.getScreenDimension();
     }


### PR DESCRIPTION
This PR fixes 
* the ARE window size and location calculation on multi display environments (especially on Linux, where Toolkit.DefaultToolkit.getScreenSize() returns the virtual screen size).
* Make use of the method AstericsGUI.getScreenDimension on all occasions.
* Max font size calculation for the TextDisplay and EditBox plugins
* introduces a method ```AstericsGUI.calcMaxFontSize()``` to have a centralized method that can be used by any plugin.
* enables anti-aliased font rendering for cellboard cell text.
* also added AstericsGUI.getMaxFontSize method, which overrides max font size to 10 in case of a low screen resolution (w < 1440 || h < 900). This **fixes #243**

## TODO
@ChrisVeigl @klues please check if everything still works fine on your windows multi screen environments. For **eye tracking** only the primary screen size makes anyway. But for the **Mouse** emulation I think the virtual screen size could also make sense.