### PR TITLE
Deinhofer/issue77 port mousecapture plugin

### DIFF
--- a/ARE/components/sensor.mousecapture/build.xml
+++ b/ARE/components/sensor.mousecapture/build.xml
@@ -14,6 +14,7 @@
         <pathelement location="bin"/>
         <pathelement location="${osgi}/org.eclipse.osgi_3.6.0.v20100517.jar"/>
         <pathelement location="${middleware}/asterics.ARE.jar"/>
+		<pathelement location="${services}/asterics.mw.jnativehook.jar"/>       	
     </path>
     
     <property name="resources" location="src/main/resources"/>

--- a/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/MouseCaptureInstance.java
+++ b/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/MouseCaptureInstance.java
@@ -26,7 +26,9 @@
 
 package eu.asterics.component.sensor.mousecapture;
 
+import eu.asterics.component.sensor.mousecapture.jni.AbstractBridge;
 import eu.asterics.component.sensor.mousecapture.jni.Bridge;
+import eu.asterics.component.sensor.mousecapture.jni.JNativeHookBridge;
 import eu.asterics.mw.data.ConversionUtils;
 import eu.asterics.mw.model.runtime.AbstractRuntimeComponentInstance;
 import eu.asterics.mw.model.runtime.IRuntimeEventListenerPort;
@@ -35,6 +37,8 @@ import eu.asterics.mw.model.runtime.IRuntimeInputPort;
 import eu.asterics.mw.model.runtime.IRuntimeOutputPort;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeEventTriggererPort;
 import eu.asterics.mw.model.runtime.impl.DefaultRuntimeOutputPort;
+import eu.asterics.mw.utils.OSUtils;
+
 import java.awt.MouseInfo;
 
 /**
@@ -56,15 +60,19 @@ public class MouseCaptureInstance extends AbstractRuntimeComponentInstance {
     private final EventTriggerPort etpWheelUp = new EventTriggerPort();
     private final EventTriggerPort etpWheelDown = new EventTriggerPort();
 
-    private final Bridge bridge = new Bridge(opMouseX, opMouseY, etpLeftButtonPressed, etpLeftButtonReleased,
-            etpRightButtonPressed, etpRightButtonReleased, etpMiddleButtonPressed, etpMiddleButtonReleased, etpWheelUp,
-            etpWheelDown);
+    private final AbstractBridge bridge;
 
     /**
      * The class constructor.
      */
     public MouseCaptureInstance() {
-        // empty constructor - needed for OSGi service factory operations
+        if (OSUtils.isWindows()) {
+            bridge = new Bridge(opMouseX, opMouseY, etpLeftButtonPressed, etpLeftButtonReleased, etpRightButtonPressed, etpRightButtonReleased,
+                    etpMiddleButtonPressed, etpMiddleButtonReleased, etpWheelUp, etpWheelDown);
+        } else {
+            bridge = new JNativeHookBridge(opMouseX, opMouseY, etpLeftButtonPressed, etpLeftButtonReleased, etpRightButtonPressed, etpRightButtonReleased,
+                    etpMiddleButtonPressed, etpMiddleButtonReleased, etpWheelUp, etpWheelDown);
+        }
     }
 
     /**

--- a/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/AbstractBridge.java
+++ b/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/AbstractBridge.java
@@ -96,7 +96,7 @@ public abstract class AbstractBridge {
      *            [Int.MIN_VALUE, Int.MAX_VALUE])
      */
     protected void newButtons_callback(final int buttonstate) {
-        System.out.println("Java: Callback buttonstate = " + Integer.toBinaryString(buttonstate));
+        //System.out.println("Java: Callback buttonstate = " + Integer.toBinaryString(buttonstate));
     
         if (((oldButtonstate & 1) == 0) && ((buttonstate & 1) != 0)) {
             eventLButtonPressed.raiseEvent();

--- a/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/AbstractBridge.java
+++ b/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/AbstractBridge.java
@@ -1,0 +1,138 @@
+package eu.asterics.component.sensor.mousecapture.jni;
+
+import eu.asterics.component.sensor.mousecapture.MouseCaptureInstance;
+import eu.asterics.mw.services.AstericsErrorHandling;
+
+public abstract class AbstractBridge {
+
+    private int oldButtonstate = 0;
+    protected MouseCaptureInstance.OutputPort mouseX;
+    protected MouseCaptureInstance.OutputPort mouseY;
+    protected MouseCaptureInstance.EventTriggerPort eventLButtonPressed;
+    protected MouseCaptureInstance.EventTriggerPort eventLButtonReleased;
+    protected MouseCaptureInstance.EventTriggerPort eventRButtonPressed;
+    protected MouseCaptureInstance.EventTriggerPort eventRButtonReleased;
+    protected MouseCaptureInstance.EventTriggerPort eventMButtonPressed;
+    protected MouseCaptureInstance.EventTriggerPort eventMButtonReleased;
+    protected MouseCaptureInstance.EventTriggerPort eventWheelUp;
+    protected MouseCaptureInstance.EventTriggerPort eventWheelDown;
+
+    public AbstractBridge() {
+        super();
+    }
+    
+    /**
+     * Activates the underlying native code/hardware.
+     *
+     * @return 0 if everything was OK, a negative number corresponding to an
+     *         error code otherwise
+     */
+    abstract public int activate();
+
+    /**
+     * Deactivates the underlying native code/hardware.
+     *
+     * @return 0 if everything was OK, a negative number corresponding to an
+     *         error code otherwise
+     */
+    abstract public int deactivate();
+
+    /**
+     * Gets the value of the named property.
+     *
+     * @param key
+     *            the name of the property to be accessed
+     * @return the value of the named property
+     */
+    abstract public String getProperty(String key);
+
+    /**
+     * Sets the named property to the defined value.
+     *
+     * @param key
+     *            the name of the property to be accessed
+     * @param value
+     *            the value to be assigned to the named property
+     * @return the value previously assigned to the named property
+     */
+    abstract public String setProperty(String key, final String value);    
+
+    /**
+     * This method is called back from the native code on demand to signify an
+     * internal error. The first argument corresponds to an error code and the
+     * second argument corresponds to a textual description of the error.
+     *
+     * @param errorCode
+     *            an error code
+     * @param message
+     *            a textual description of the error
+     */
+    protected void errorReport_callback(final int errorCode, final String message) {
+        AstericsErrorHandling.instance.getLogger().fine(errorCode + ": " + message);
+    }
+
+    /**
+     * This method is called back from the native code on demand. The passed
+     * arguments correspond to the x and y movement of the mouse
+     *
+     * @param x_value
+     *            the x movement (range is [Int.MIN_VALUE, Int.MAX_VALUE])
+     * @param a_value
+     *            the a movement (range is [Int.MIN_VALUE, Int.MAX_VALUE])
+     */
+    protected void newCoordinates_callback(final int x_value, final int y_value) {
+        mouseX.sendData(x_value);
+        mouseY.sendData(y_value);
+    
+    }
+
+    /**
+     * This method is called back from the native code on demand. The passed
+     * argument holds the left mouse button state in bit 0, the right mouse
+     * button state in bit 1 and the middle mouse button state in bit 2
+     *
+     * @param buttonstate
+     *            left/right/middle mouse button in bit 0/1/2 (range is
+     *            [Int.MIN_VALUE, Int.MAX_VALUE])
+     */
+    protected void newButtons_callback(final int buttonstate) {
+        System.out.println("Java: Callback buttonstate = " + Integer.toBinaryString(buttonstate));
+    
+        if (((oldButtonstate & 1) == 0) && ((buttonstate & 1) != 0)) {
+            eventLButtonPressed.raiseEvent();
+        } else if (((oldButtonstate & 1) != 0) && ((buttonstate & 1) == 0)) {
+            eventLButtonReleased.raiseEvent();
+        }
+    
+        if (((oldButtonstate & 2) == 0) && ((buttonstate & 2) != 0)) {
+            eventRButtonPressed.raiseEvent();
+        } else if (((oldButtonstate & 2) != 0) && ((buttonstate & 2) == 0)) {
+            eventRButtonReleased.raiseEvent();
+        }
+    
+        if (((oldButtonstate & 4) == 0) && ((buttonstate & 4) != 0)) {
+            eventMButtonPressed.raiseEvent();
+        } else if (((oldButtonstate & 4) != 0) && ((buttonstate & 4) == 0)) {
+            eventMButtonReleased.raiseEvent();
+        }
+    
+        oldButtonstate = buttonstate;
+    
+    }
+
+    /**
+     * This method is called back from the native code on demand. The passed
+     * argument holds the mouse wheel movement (1 = wheel up, -1 = wheel down)
+     *
+     * @param wheel
+     *            int 1/-1 (range is [-1, 1])
+     */
+    protected void newWheel_callback(final int wheel) {
+        if (wheel > 0) {
+            eventWheelUp.raiseEvent();
+        } else {
+            eventWheelDown.raiseEvent();
+        }
+    }
+
+}

--- a/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/Bridge.java
+++ b/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/Bridge.java
@@ -53,6 +53,8 @@ public class Bridge extends AbstractBridge {
             final MouseCaptureInstance.EventTriggerPort eventMButtonReleased,
             final MouseCaptureInstance.EventTriggerPort eventWheelUp,
             final MouseCaptureInstance.EventTriggerPort eventWheelDown) {
+    	AstericsErrorHandling.instance.getLogger().fine("Initializing native windows Bridge for mouse capturing...");
+    	
         this.mouseX = mouse_x;
         this.mouseY = mouse_y;
         this.eventLButtonPressed = eventLButtonPressed;

--- a/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/Bridge.java
+++ b/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/Bridge.java
@@ -35,7 +35,7 @@ import eu.asterics.mw.services.AstericsErrorHandling;
  * @author Chris Veigl [veigl@technikum-wien.at] Date: Mar 1, 2011 Time: 3:35:00
  *         PM
  */
-public class Bridge {
+public class Bridge extends AbstractBridge {
     /**
      * Statically load the native library
      */
@@ -43,19 +43,6 @@ public class Bridge {
         System.loadLibrary("syshook");
         AstericsErrorHandling.instance.getLogger().fine("Loading \"syshook.dll\" ... ok!");
     }
-
-    private int oldButtonstate = 0;
-
-    private final MouseCaptureInstance.OutputPort mouseX;
-    private final MouseCaptureInstance.OutputPort mouseY;
-    private final MouseCaptureInstance.EventTriggerPort eventLButtonPressed;
-    private final MouseCaptureInstance.EventTriggerPort eventLButtonReleased;
-    private final MouseCaptureInstance.EventTriggerPort eventRButtonPressed;
-    private final MouseCaptureInstance.EventTriggerPort eventRButtonReleased;
-    private final MouseCaptureInstance.EventTriggerPort eventMButtonPressed;
-    private final MouseCaptureInstance.EventTriggerPort eventMButtonReleased;
-    private final MouseCaptureInstance.EventTriggerPort eventWheelUp;
-    private final MouseCaptureInstance.EventTriggerPort eventWheelDown;
 
     public Bridge(final MouseCaptureInstance.OutputPort mouse_x, final MouseCaptureInstance.OutputPort mouse_y,
             final MouseCaptureInstance.EventTriggerPort eventLButtonPressed,
@@ -113,83 +100,5 @@ public class Bridge {
      * @return the value previously assigned to the named property
      */
     native public String setProperty(String key, final String value);
-
-    /**
-     * This method is called back from the native code on demand to signify an
-     * internal error. The first argument corresponds to an error code and the
-     * second argument corresponds to a textual description of the error.
-     *
-     * @param errorCode
-     *            an error code
-     * @param message
-     *            a textual description of the error
-     */
-    private void errorReport_callback(final int errorCode, final String message) {
-        AstericsErrorHandling.instance.getLogger().fine(errorCode + ": " + message);
-    }
-
-    /**
-     * This method is called back from the native code on demand. The passed
-     * arguments correspond to the x and y movement of the mouse
-     *
-     * @param x_value
-     *            the x movement (range is [Int.MIN_VALUE, Int.MAX_VALUE])
-     * @param a_value
-     *            the a movement (range is [Int.MIN_VALUE, Int.MAX_VALUE])
-     */
-    private void newCoordinates_callback(final int x_value, final int y_value) {
-        mouseX.sendData(x_value);
-        mouseY.sendData(y_value);
-
-    }
-
-    /**
-     * This method is called back from the native code on demand. The passed
-     * argument holds the left mouse button state in bit 0, the right mouse
-     * button state in bit 1 and the middle mouse button state in bit 2
-     *
-     * @param buttonstate
-     *            left/right/middle mouse button in bit 0/1/2 (range is
-     *            [Int.MIN_VALUE, Int.MAX_VALUE])
-     */
-    private void newButtons_callback(final int buttonstate) {
-        // System.out.println("Java: Callback buttonstate = " + buttonstate);
-
-        if (((oldButtonstate & 1) == 0) && ((buttonstate & 1) != 0)) {
-            eventLButtonPressed.raiseEvent();
-        } else if (((oldButtonstate & 1) != 0) && ((buttonstate & 1) == 0)) {
-            eventLButtonReleased.raiseEvent();
-        }
-
-        if (((oldButtonstate & 2) == 0) && ((buttonstate & 2) != 0)) {
-            eventRButtonPressed.raiseEvent();
-        } else if (((oldButtonstate & 2) != 0) && ((buttonstate & 2) == 0)) {
-            eventRButtonReleased.raiseEvent();
-        }
-
-        if (((oldButtonstate & 4) == 0) && ((buttonstate & 4) != 0)) {
-            eventMButtonPressed.raiseEvent();
-        } else if (((oldButtonstate & 4) != 0) && ((buttonstate & 4) == 0)) {
-            eventMButtonReleased.raiseEvent();
-        }
-
-        oldButtonstate = buttonstate;
-
-    }
-
-    /**
-     * This method is called back from the native code on demand. The passed
-     * argument holds the mouse wheel movement (1 = wheel up, -1 = wheel down)
-     *
-     * @param wheel
-     *            int 1/-1 (range is [-1, 1])
-     */
-    private void newWheel_callback(final int wheel) {
-        if (wheel > 0) {
-            eventWheelUp.raiseEvent();
-        } else {
-            eventWheelDown.raiseEvent();
-        }
-    }
 
 }

--- a/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/JNativeHookBridge.java
+++ b/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/JNativeHookBridge.java
@@ -143,12 +143,12 @@ public class JNativeHookBridge extends AbstractBridge implements NativeMouseInpu
             eventLButtonPressed.raiseEvent();
             break;
         case NativeMouseEvent.BUTTON2:
-            // right
-            eventRButtonPressed.raiseEvent();
-            break;
-        case NativeMouseEvent.BUTTON3:
             // middle
             eventMButtonPressed.raiseEvent();
+            break;
+        case NativeMouseEvent.BUTTON3:
+            // right
+            eventRButtonPressed.raiseEvent();
             break;
         }
     }
@@ -165,12 +165,12 @@ public class JNativeHookBridge extends AbstractBridge implements NativeMouseInpu
             eventLButtonReleased.raiseEvent();
             break;
         case NativeMouseEvent.BUTTON2:
-            // right
-            eventRButtonReleased.raiseEvent();
-            break;
-        case NativeMouseEvent.BUTTON3:
             // middle
             eventMButtonReleased.raiseEvent();
+            break;
+        case NativeMouseEvent.BUTTON3:
+            // right
+            eventRButtonReleased.raiseEvent();
             break;
         }
     }

--- a/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/JNativeHookBridge.java
+++ b/ARE/components/sensor.mousecapture/src/main/java/eu/asterics/component/sensor/mousecapture/jni/JNativeHookBridge.java
@@ -1,0 +1,173 @@
+/*
+ *    AsTeRICS - Assistive Technology Rapid Integration and Construction Set
+ * 
+ * 
+ *        d8888      88888888888       8888888b.  8888888 .d8888b.   .d8888b. 
+ *       d88888          888           888   Y88b   888  d88P  Y88b d88P  Y88b
+ *      d88P888          888           888    888   888  888    888 Y88b.     
+ *     d88P 888 .d8888b  888   .d88b.  888   d88P   888  888         "Y888b.  
+ *    d88P  888 88K      888  d8P  Y8b 8888888P"    888  888            "Y88b.
+ *   d88P   888 "Y8888b. 888  88888888 888 T88b     888  888    888       "888
+ *  d8888888888      X88 888  Y8b.     888  T88b    888  Y88b  d88P Y88b  d88P
+ * d88P     888  88888P' 888   "Y8888  888   T88b 8888888 "Y8888P"   "Y8888P" 
+ *
+ *
+ *                    homepage: http://www.asterics.org 
+ *
+ *         This project has been funded by the European Commission, 
+ *                      Grant Agreement Number 247730
+ *  
+ *  
+ *         Dual License: MIT or GPL v3.0 with "CLASSPATH" exception
+ *         (please refer to the folder LICENSE)
+ * 
+ */
+package eu.asterics.component.sensor.mousecapture.jni;
+
+import org.jnativehook.GlobalScreen;
+import org.jnativehook.mouse.NativeMouseEvent;
+import org.jnativehook.mouse.NativeMouseInputListener;
+import org.jnativehook.mouse.NativeMouseListener;
+import org.jnativehook.mouse.NativeMouseMotionListener;
+import org.jnativehook.mouse.NativeMouseWheelEvent;
+import org.jnativehook.mouse.NativeMouseWheelListener;
+
+import eu.asterics.component.sensor.mousecapture.MouseCaptureInstance;
+import eu.asterics.mw.jnativehook.NativeHookServices;
+
+/**
+ * <Describe purpose of this module>
+ * 
+ * @author mad <e-mail address>
+ * @date Apr 19, 2019
+ *
+ */
+public class JNativeHookBridge extends AbstractBridge implements NativeMouseInputListener, NativeMouseWheelListener {
+
+    public JNativeHookBridge(final MouseCaptureInstance.OutputPort mouse_x, final MouseCaptureInstance.OutputPort mouse_y,
+            final MouseCaptureInstance.EventTriggerPort eventLButtonPressed, final MouseCaptureInstance.EventTriggerPort eventLButtonReleased,
+            final MouseCaptureInstance.EventTriggerPort eventRButtonPressed, final MouseCaptureInstance.EventTriggerPort eventRButtonReleased,
+            final MouseCaptureInstance.EventTriggerPort eventMButtonPressed, final MouseCaptureInstance.EventTriggerPort eventMButtonReleased,
+            final MouseCaptureInstance.EventTriggerPort eventWheelUp, final MouseCaptureInstance.EventTriggerPort eventWheelDown) {
+        this.mouseX = mouse_x;
+        this.mouseY = mouse_y;
+        this.eventLButtonPressed = eventLButtonPressed;
+        this.eventLButtonReleased = eventLButtonReleased;
+        this.eventRButtonPressed = eventRButtonPressed;
+        this.eventRButtonReleased = eventRButtonReleased;
+        this.eventMButtonPressed = eventMButtonPressed;
+        this.eventMButtonReleased = eventMButtonReleased;
+        this.eventWheelUp = eventWheelUp;
+        this.eventWheelDown = eventWheelDown;
+
+        // Ensure that the NativeHookServices are initialized at least once.
+        NativeHookServices.init();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see eu.asterics.component.sensor.mousecapture.jni.AbstractBridge#activate()
+     */
+    @Override
+    public int activate() {
+        GlobalScreen.addNativeMouseListener(this);
+        GlobalScreen.addNativeMouseMotionListener(this);
+        GlobalScreen.addNativeMouseWheelListener(this);
+        return 0;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see eu.asterics.component.sensor.mousecapture.jni.AbstractBridge#deactivate()
+     */
+    @Override
+    public int deactivate() {
+        GlobalScreen.removeNativeMouseListener(this);
+        GlobalScreen.removeNativeMouseMotionListener(this);
+        GlobalScreen.removeNativeMouseWheelListener(this);
+        return 0;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see eu.asterics.component.sensor.mousecapture.jni.AbstractBridge#getProperty(java.lang.String)
+     */
+    @Override
+    public String getProperty(String key) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see eu.asterics.component.sensor.mousecapture.jni.AbstractBridge#setProperty(java.lang.String, java.lang.String)
+     */
+    @Override
+    public String setProperty(String key, String value) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void nativeMouseClicked(NativeMouseEvent arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void nativeMousePressed(NativeMouseEvent arg0) {
+        switch(arg0.getButton()) {
+        case NativeMouseEvent.BUTTON1:
+            //left
+            newButtons_callback(0x1);
+            break;
+        case NativeMouseEvent.BUTTON2:
+            //right
+            newButtons_callback(0x4);
+            break;
+        case NativeMouseEvent.BUTTON3:
+            //middle
+            newButtons_callback(0x2);
+            break;            
+        }
+    }
+
+    @Override
+    public void nativeMouseReleased(NativeMouseEvent arg0) {
+        switch(arg0.getButton()) {
+        case NativeMouseEvent.BUTTON1:
+            //left
+            newButtons_callback(0x1);
+            break;
+        case NativeMouseEvent.BUTTON2:
+            //right
+            newButtons_callback(0x4);
+            break;
+        case NativeMouseEvent.BUTTON3:
+            //middle
+            newButtons_callback(0x2);
+            break;            
+        }
+    }
+
+    @Override
+    public void nativeMouseDragged(NativeMouseEvent arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void nativeMouseMoved(NativeMouseEvent arg0) {
+        newCoordinates_callback(arg0.getX(), arg0.getY());
+    }
+
+    @Override
+    public void nativeMouseWheelMoved(NativeMouseWheelEvent arg0) {
+        newWheel_callback(arg0.getWheelRotation());
+    }
+
+}

--- a/ARE/components/sensor.mousecapture/src/main/resources/META-INF/MANIFEST.MF
+++ b/ARE/components/sensor.mousecapture/src/main/resources/META-INF/MANIFEST.MF
@@ -6,5 +6,9 @@ Bundle-Version: 0.1.0
 Bundle-NativeCode: lib/native/windows/x86/syshook.dll;
  osname=win32;processor=x86,
  lib/native/windows/x64/syshook.dll;
- osname=win32;processor=x86_64
+ osname=win32;processor=x86_64,
+ lib/native/windows/x64/syshook.dll;
+ osname=Linux,
+ lib/native/windows/x64/syshook.dll;
+ osname=MacOSX 
 DynamicImport-Package: *

--- a/bin/ARE/models/componentTests/sensors/MouseCapture_test.acs
+++ b/bin/ARE/models/componentTests/sensors/MouseCapture_test.acs
@@ -1,253 +1,1 @@
-<?xml version="1.0"?>
-<model xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" modelName="C:\modelconvert\ACS\componentTests\sensors\MouseCapture_test.acs_2017_12_14_11_48" version="20130320">
-  <components>
-    <component id="MouseCapture.1" type_id="asterics.MouseCapture">
-      <description>Captures mouse cursor activity from local system</description>
-      <ports>
-        <outputPort portTypeID="mouseX">
-          <properties />
-        </outputPort>
-        <outputPort portTypeID="mouseY">
-          <properties />
-        </outputPort>
-      </ports>
-      <properties>
-        <property name="blockEvents" value="False" />
-      </properties>
-      <layout>
-        <posX>52</posX>
-        <posY>55</posY>
-      </layout>
-    </component>
-    <component id="Oscilloscope.1" type_id="asterics.Oscilloscope">
-      <description>Oscilloscope display for one signal channel</description>
-      <ports>
-        <inputPort portTypeID="in">
-          <properties />
-        </inputPort>
-      </ports>
-      <properties>
-        <property name="displayBuffer" value="3" />
-        <property name="drawingMode" value="0" />
-        <property name="displayMode" value="0" />
-        <property name="drawingInterval" value="100" />
-        <property name="min" value="-100" />
-        <property name="max" value="100" />
-        <property name="gridColor" value="0" />
-        <property name="channelColor" value="10" />
-        <property name="backgroundColor" value="11" />
-        <property name="fontSize" value="14" />
-        <property name="caption" value="Mouse-X" />
-        <property name="displayGUI" value="true" />
-      </properties>
-      <layout>
-        <posX>246</posX>
-        <posY>25</posY>
-      </layout>
-      <gui>
-        <posX>0</posX>
-        <posY>822</posY>
-        <width>5400</width>
-        <height>3000</height>
-      </gui>
-    </component>
-    <component id="Oscilloscope.2" type_id="asterics.Oscilloscope">
-      <description>Oscilloscope display for one signal channel</description>
-      <ports>
-        <inputPort portTypeID="in">
-          <properties />
-        </inputPort>
-      </ports>
-      <properties>
-        <property name="displayBuffer" value="3" />
-        <property name="drawingMode" value="0" />
-        <property name="displayMode" value="0" />
-        <property name="drawingInterval" value="100" />
-        <property name="min" value="-100" />
-        <property name="max" value="100" />
-        <property name="gridColor" value="0" />
-        <property name="channelColor" value="10" />
-        <property name="backgroundColor" value="11" />
-        <property name="fontSize" value="14" />
-        <property name="caption" value="Mouse-Y" />
-        <property name="displayGUI" value="true" />
-      </properties>
-      <layout>
-        <posX>338</posX>
-        <posY>159</posY>
-      </layout>
-      <gui>
-        <posX>0</posX>
-        <posY>3911</posY>
-        <width>5400</width>
-        <height>3200</height>
-      </gui>
-    </component>
-    <component id="EventVisualizer.1" type_id="asterics.EventVisualizer">
-      <description>Simple Event Visualizer</description>
-      <ports />
-      <properties>
-        <property name="displayGUI" value="true" />
-      </properties>
-      <layout>
-        <posX>162</posX>
-        <posY>204</posY>
-      </layout>
-      <gui>
-        <posX>5475</posX>
-        <posY>1533</posY>
-        <width>2700</width>
-        <height>5000</height>
-      </gui>
-    </component>
-  </components>
-  <channels>
-    <channel id="binding.0">
-      <source>
-        <component id="MouseCapture.1" />
-        <port id="mouseX" />
-      </source>
-      <target>
-        <component id="Oscilloscope.1" />
-        <port id="in" />
-      </target>
-    </channel>
-    <channel id="binding.1">
-      <source>
-        <component id="MouseCapture.1" />
-        <port id="mouseY" />
-      </source>
-      <target>
-        <component id="Oscilloscope.2" />
-        <port id="in" />
-      </target>
-    </channel>
-  </channels>
-  <eventChannels>
-    <eventChannel id="leftButtonPressed_eventDisplay">
-      <sources>
-        <source>
-          <component id="MouseCapture.1" />
-          <eventPort id="leftButtonPressed" />
-        </source>
-      </sources>
-      <targets>
-        <target>
-          <component id="EventVisualizer.1" />
-          <eventPort id="eventDisplay" />
-        </target>
-      </targets>
-    </eventChannel>
-    <eventChannel id="leftButtonReleased_eventDisplay">
-      <sources>
-        <source>
-          <component id="MouseCapture.1" />
-          <eventPort id="leftButtonReleased" />
-        </source>
-      </sources>
-      <targets>
-        <target>
-          <component id="EventVisualizer.1" />
-          <eventPort id="eventDisplay" />
-        </target>
-      </targets>
-    </eventChannel>
-    <eventChannel id="rightButtonPressed_eventDisplay">
-      <sources>
-        <source>
-          <component id="MouseCapture.1" />
-          <eventPort id="rightButtonPressed" />
-        </source>
-      </sources>
-      <targets>
-        <target>
-          <component id="EventVisualizer.1" />
-          <eventPort id="eventDisplay" />
-        </target>
-      </targets>
-    </eventChannel>
-    <eventChannel id="rightButtonReleased_eventDisplay">
-      <sources>
-        <source>
-          <component id="MouseCapture.1" />
-          <eventPort id="rightButtonReleased" />
-        </source>
-      </sources>
-      <targets>
-        <target>
-          <component id="EventVisualizer.1" />
-          <eventPort id="eventDisplay" />
-        </target>
-      </targets>
-    </eventChannel>
-    <eventChannel id="middleButtonPressed_eventDisplay">
-      <sources>
-        <source>
-          <component id="MouseCapture.1" />
-          <eventPort id="middleButtonPressed" />
-        </source>
-      </sources>
-      <targets>
-        <target>
-          <component id="EventVisualizer.1" />
-          <eventPort id="eventDisplay" />
-        </target>
-      </targets>
-    </eventChannel>
-    <eventChannel id="middleButtonReleased_eventDisplay">
-      <sources>
-        <source>
-          <component id="MouseCapture.1" />
-          <eventPort id="middleButtonReleased" />
-        </source>
-      </sources>
-      <targets>
-        <target>
-          <component id="EventVisualizer.1" />
-          <eventPort id="eventDisplay" />
-        </target>
-      </targets>
-    </eventChannel>
-    <eventChannel id="wheelUp_eventDisplay">
-      <sources>
-        <source>
-          <component id="MouseCapture.1" />
-          <eventPort id="wheelUp" />
-        </source>
-      </sources>
-      <targets>
-        <target>
-          <component id="EventVisualizer.1" />
-          <eventPort id="eventDisplay" />
-        </target>
-      </targets>
-    </eventChannel>
-    <eventChannel id="wheelDown_eventDisplay">
-      <sources>
-        <source>
-          <component id="MouseCapture.1" />
-          <eventPort id="wheelDown" />
-        </source>
-      </sources>
-      <targets>
-        <target>
-          <component id="EventVisualizer.1" />
-          <eventPort id="eventDisplay" />
-        </target>
-      </targets>
-    </eventChannel>
-  </eventChannels>
-  <modelGUI>
-    <Decoration>true</Decoration>
-    <Fullscreen>false</Fullscreen>
-    <AlwaysOnTop>false</AlwaysOnTop>
-    <ToSystemTray>false</ToSystemTray>
-    <ShopControlPanel>true</ShopControlPanel>
-    <AREGUIWindow>
-      <posX>0</posX>
-      <posY>0</posY>
-      <width>8788</width>
-      <height>7111</height>
-    </AREGUIWindow>
-  </modelGUI>
-</model>
+<?xml version="1.0"?><model xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" modelName="C:\modelconvert\ACS\componentTests\sensors\MouseCapture_test.acs_2017_12_14_11_48" version="20130320">	<modelDescription>		<shortDescription></shortDescription>		<requirements></requirements>		<description></description>	</modelDescription>	<components>		<component id="MouseCapture.1" type_id="asterics.MouseCapture">			<description>Captures mouse cursor activity from local system</description>			<ports>				<outputPort portTypeID="mouseX">					<properties />				</outputPort>				<outputPort portTypeID="mouseY">					<properties />				</outputPort>			</ports>			<properties>				<property name="blockEvents" value="False" />			</properties>			<layout>				<posX>52</posX>				<posY>55</posY>			</layout>		</component>		<component id="Oscilloscope.1" type_id="asterics.Oscilloscope">			<description>Oscilloscope display for one signal channel</description>			<ports>				<inputPort portTypeID="in" sync="false">					<properties />				</inputPort>			</ports>			<properties>				<property name="displayBuffer" value="3" />				<property name="drawingMode" value="0" />				<property name="displayMode" value="0" />				<property name="drawingInterval" value="100" />				<property name="min" value="-100" />				<property name="max" value="100" />				<property name="gridColor" value="0" />				<property name="channelColor" value="10" />				<property name="backgroundColor" value="11" />				<property name="fontSize" value="14" />				<property name="caption" value="Mouse-X" />				<property name="displayGUI" value="true" />			</properties>			<layout>				<posX>246</posX>				<posY>25</posY>			</layout>			<gui>				<posX>0</posX>				<posY>822</posY>				<width>5400</width>				<height>3000</height>			</gui>		</component>		<component id="Oscilloscope.2" type_id="asterics.Oscilloscope">			<description>Oscilloscope display for one signal channel</description>			<ports>				<inputPort portTypeID="in" sync="false">					<properties />				</inputPort>			</ports>			<properties>				<property name="displayBuffer" value="3" />				<property name="drawingMode" value="0" />				<property name="displayMode" value="0" />				<property name="drawingInterval" value="100" />				<property name="min" value="-100" />				<property name="max" value="100" />				<property name="gridColor" value="0" />				<property name="channelColor" value="10" />				<property name="backgroundColor" value="11" />				<property name="fontSize" value="14" />				<property name="caption" value="Mouse-Y" />				<property name="displayGUI" value="true" />			</properties>			<layout>				<posX>338</posX>				<posY>159</posY>			</layout>			<gui>				<posX>0</posX>				<posY>3911</posY>				<width>5400</width>				<height>3200</height>			</gui>		</component>		<component id="EventVisualizer.1" type_id="asterics.EventVisualizer">			<description>Simple Event Visualizer</description>			<ports />			<properties>				<property name="displayGUI" value="true" />			</properties>			<layout>				<posX>162</posX>				<posY>204</posY>			</layout>			<gui>				<posX>5417</posX>				<posY>2852</posY>				<width>2708</width>				<height>4259</height>			</gui>		</component>		<component id="ButtonGrid.1" type_id="asterics.ButtonGrid">			<description>Keyboard which sends event after button press</description>			<ports />			<properties>				<property name="caption" value="Keyboard" />				<property name="horizontalOrientation" value="true" />				<property name="textColor" value="13" />				<property name="backgroundColor" value="13" />				<property name="borderColor" value="13" />				<property name="borderThickness" value="2" />				<property name="selectionFrameColor" value="13" />				<property name="selectionFrameThickness" value="4" />				<property name="displayGUI" value="true" />				<property name="buttonCaption1" value="Block" />				<property name="buttonCaption2" value="Forward" />				<property name="buttonCaption3" value="Toggle" />				<property name="buttonCaption4" value="PollMouse" />				<property name="buttonCaption5" value="" />				<property name="buttonCaption6" value="" />				<property name="buttonCaption7" value="" />				<property name="buttonCaption8" value="" />				<property name="buttonCaption9" value="" />				<property name="buttonCaption10" value="" />				<property name="buttonCaption11" value="" />				<property name="buttonCaption12" value="" />				<property name="buttonCaption13" value="" />				<property name="buttonCaption14" value="" />				<property name="buttonCaption15" value="" />				<property name="buttonCaption16" value="" />				<property name="buttonCaption17" value="" />				<property name="buttonCaption18" value="" />				<property name="buttonCaption19" value="" />				<property name="buttonCaption20" value="" />				<property name="toolTip1" value="" />				<property name="toolTip2" value="" />				<property name="toolTip3" value="" />				<property name="toolTip4" value="" />				<property name="toolTip5" value="" />				<property name="toolTip6" value="" />				<property name="toolTip7" value="" />				<property name="toolTip8" value="" />				<property name="toolTip9" value="" />				<property name="toolTip10" value="" />				<property name="toolTip11" value="" />				<property name="toolTip12" value="" />				<property name="toolTip13" value="" />				<property name="toolTip14" value="" />				<property name="toolTip15" value="" />				<property name="toolTip16" value="" />				<property name="toolTip17" value="" />				<property name="toolTip18" value="" />				<property name="toolTip19" value="" />				<property name="toolTip20" value="" />			</properties>			<layout>				<posX>33</posX>				<posY>276</posY>			</layout>			<gui>				<posX>5417</posX>				<posY>1481</posY>				<width>2708</width>				<height>1296</height>			</gui>		</component>		<component id="KeyCapture.1" type_id="asterics.KeyCapture">			<description>captures key presses and releases for a single keyboard key</description>			<ports>				<inputPort portTypeID="keyCode" sync="false">					<properties />				</inputPort>			</ports>			<properties>				<property name="keyCode" value="3639" />				<property name="block" value="false" />			</properties>			<layout>				<posX>297</posX>				<posY>323</posY>			</layout>		</component>		<component id="TextDisplay.1" type_id="asterics.TextDisplay">			<description>GUI component, which displays text.</description>			<ports>				<inputPort portTypeID="input" sync="false">					<properties />				</inputPort>			</ports>			<properties>				<property name="caption" value="Forward Events" />				<property name="default" value="Press &apos;Print&apos; Key" />				<property name="textPosition" value="1" />				<property name="textColor" value="0" />				<property name="backgroundColor" value="11" />				<property name="displayGUI" value="true" />			</properties>			<layout>				<posX>550</posX>				<posY>78</posY>			</layout>			<gui>				<posX>5417</posX>				<posY>741</posY>				<width>2708</width>				<height>740</height>			</gui>		</component>	</components>	<channels>		<channel id="binding.0">			<source>				<component id="MouseCapture.1" />				<port id="mouseX" />			</source>			<target>				<component id="Oscilloscope.1" />				<port id="in" />			</target>		</channel>		<channel id="binding.1">			<source>				<component id="MouseCapture.1" />				<port id="mouseY" />			</source>			<target>				<component id="Oscilloscope.2" />				<port id="in" />			</target>		</channel>	</channels>	<eventChannels>		<eventChannel id="leftButtonPressed_eventDisplay">			<sources>				<source>					<component id="MouseCapture.1" />					<eventPort id="leftButtonPressed" />				</source>			</sources>			<targets>				<target>					<component id="EventVisualizer.1" />					<eventPort id="eventDisplay" />				</target>			</targets>		</eventChannel>		<eventChannel id="leftButtonReleased_eventDisplay">			<sources>				<source>					<component id="MouseCapture.1" />					<eventPort id="leftButtonReleased" />				</source>			</sources>			<targets>				<target>					<component id="EventVisualizer.1" />					<eventPort id="eventDisplay" />				</target>			</targets>		</eventChannel>		<eventChannel id="rightButtonPressed_eventDisplay">			<sources>				<source>					<component id="MouseCapture.1" />					<eventPort id="rightButtonPressed" />				</source>			</sources>			<targets>				<target>					<component id="EventVisualizer.1" />					<eventPort id="eventDisplay" />				</target>			</targets>		</eventChannel>		<eventChannel id="rightButtonReleased_eventDisplay">			<sources>				<source>					<component id="MouseCapture.1" />					<eventPort id="rightButtonReleased" />				</source>			</sources>			<targets>				<target>					<component id="EventVisualizer.1" />					<eventPort id="eventDisplay" />				</target>			</targets>		</eventChannel>		<eventChannel id="middleButtonPressed_eventDisplay">			<sources>				<source>					<component id="MouseCapture.1" />					<eventPort id="middleButtonPressed" />				</source>			</sources>			<targets>				<target>					<component id="EventVisualizer.1" />					<eventPort id="eventDisplay" />				</target>			</targets>		</eventChannel>		<eventChannel id="middleButtonReleased_eventDisplay">			<sources>				<source>					<component id="MouseCapture.1" />					<eventPort id="middleButtonReleased" />				</source>			</sources>			<targets>				<target>					<component id="EventVisualizer.1" />					<eventPort id="eventDisplay" />				</target>			</targets>		</eventChannel>		<eventChannel id="wheelUp_eventDisplay">			<sources>				<source>					<component id="MouseCapture.1" />					<eventPort id="wheelUp" />				</source>			</sources>			<targets>				<target>					<component id="EventVisualizer.1" />					<eventPort id="eventDisplay" />				</target>			</targets>		</eventChannel>		<eventChannel id="wheelDown_eventDisplay">			<sources>				<source>					<component id="MouseCapture.1" />					<eventPort id="wheelDown" />				</source>			</sources>			<targets>				<target>					<component id="EventVisualizer.1" />					<eventPort id="eventDisplay" />				</target>			</targets>		</eventChannel>		<eventChannel id="button1_blockEvents">			<sources>				<source>					<component id="ButtonGrid.1" />					<eventPort id="button1" />				</source>			</sources>			<targets>				<target>					<component id="MouseCapture.1" />					<eventPort id="blockEvents" />				</target>			</targets>		</eventChannel>		<eventChannel id="button2_forwardEvents">			<sources>				<source>					<component id="ButtonGrid.1" />					<eventPort id="button2" />				</source>			</sources>			<targets>				<target>					<component id="MouseCapture.1" />					<eventPort id="forwardEvents" />				</target>			</targets>		</eventChannel>		<eventChannel id="button3_toggleBlock">			<sources>				<source>					<component id="ButtonGrid.1" />					<eventPort id="button3" />				</source>			</sources>			<targets>				<target>					<component id="MouseCapture.1" />					<eventPort id="toggleBlock" />				</target>			</targets>		</eventChannel>		<eventChannel id="button4_pollMousePosition">			<sources>				<source>					<component id="ButtonGrid.1" />					<eventPort id="button4" />				</source>			</sources>			<targets>				<target>					<component id="MouseCapture.1" />					<eventPort id="pollMousePosition" />				</target>			</targets>		</eventChannel>		<eventChannel id="keyPressed_forwardEvents">			<sources>				<source>					<component id="KeyCapture.1" />					<eventPort id="keyPressed" />				</source>			</sources>			<targets>				<target>					<component id="MouseCapture.1" />					<eventPort id="forwardEvents" />				</target>			</targets>		</eventChannel>	</eventChannels>	<modelGUI>		<Decoration>true</Decoration>		<Fullscreen>false</Fullscreen>		<AlwaysOnTop>false</AlwaysOnTop>		<ToSystemTray>false</ToSystemTray>		<ShopControlPanel>true</ShopControlPanel>		<AREGUIWindow>			<posX>0</posX>			<posY>0</posY>			<width>8788</width>			<height>7111</height>		</AREGUIWindow>	</modelGUI></model>


### PR DESCRIPTION
Port of MouseCapture plugin using JNativeHook (Fixes #77) 
 * extracted generic parts of class Bridge to super class AbstractBridge
 * Implemented subclass JNativeHookBrdige which uses the jnativehook lib
 * On windows the windows Bridge is loaded, on the other platforms the JNativeHookBridge is loaded
 * 99% of the functionality could be ported, only on Linux the mouse click events are not blocked.
 * improved model to test capturing including buttons for  blocking/forwarding