### PR TITLE
Klaus/change rest methods to post

### DIFF
--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java
@@ -1,26 +1,26 @@
 /*
  *    AsTeRICS - Assistive Technology Rapid Integration and Construction Set
- * 
- * 
- *        d8888      88888888888       8888888b.  8888888 .d8888b.   .d8888b. 
+ *
+ *
+ *        d8888      88888888888       8888888b.  8888888 .d8888b.   .d8888b.
  *       d88888          888           888   Y88b   888  d88P  Y88b d88P  Y88b
- *      d88P888          888           888    888   888  888    888 Y88b.     
- *     d88P 888 .d8888b  888   .d88b.  888   d88P   888  888         "Y888b.  
+ *      d88P888          888           888    888   888  888    888 Y88b.
+ *     d88P 888 .d8888b  888   .d88b.  888   d88P   888  888         "Y888b.
  *    d88P  888 88K      888  d8P  Y8b 8888888P"    888  888            "Y88b.
  *   d88P   888 "Y8888b. 888  88888888 888 T88b     888  888    888       "888
  *  d8888888888      X88 888  Y8b.     888  T88b    888  Y88b  d88P Y88b  d88P
- * d88P     888  88888P' 888   "Y8888  888   T88b 8888888 "Y8888P"   "Y8888P" 
+ * d88P     888  88888P' 888   "Y8888  888   T88b 8888888 "Y8888P"   "Y8888P"
  *
  *
- *                    homepage: http://www.asterics.org 
+ *                    homepage: http://www.asterics.org
  *
- *         This project has been funded by the European Commission, 
+ *         This project has been funded by the European Commission,
  *                      Grant Agreement Number 247730
- *  
- *  
+ *
+ *
  *         Dual License: MIT or GPL v3.0 with "CLASSPATH" exception
  *         (please refer to the folder LICENSE)
- * 
+ *
  */
 
 package eu.asterics.mw.webservice;
@@ -76,6 +76,14 @@ public class RestServer {
     private AsapiSupport asapiSupport = new AsapiSupport();
     private Logger logger = AstericsErrorHandling.instance.getLogger();
     private AstericsAPIEncoding astericsAPIEncoding = new AstericsAPIEncoding();
+
+    @Path("/version")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Description("Returns the current ARE version")
+    public String getVersion() {
+        return "#{APPLICATION_VERSION_NUMBER}#";
+    }
 
     @Path("/restfunctions")
     @GET

--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java
@@ -136,7 +136,6 @@ public class RestServer {
 
     @Path("/runtime/model")
     @POST
-    @Consumes(MediaType.TEXT_XML)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Deploys the model given as XML body parameter")
     public String deployModel(String modelInXML) {
@@ -157,7 +156,6 @@ public class RestServer {
 
     @Path("/runtime/model")
     @PUT
-    @Consumes(MediaType.TEXT_XML)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Deploys the model given as XML body parameter")
     @Deprecated
@@ -419,7 +417,6 @@ public class RestServer {
 
     @Path("/runtime/model/components/{componentId}/{propertyKey}")
     @POST
-    @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Changes a property value of a model component")
     public String setRuntimeComponentProperty(String value, @PathParam("componentId") String componentId, @PathParam("propertyKey") String propertyKey) {
@@ -442,7 +439,6 @@ public class RestServer {
 
     @Path("/runtime/model/components/{componentId}/{propertyKey}")
     @PUT
-    @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Changes a property value of a model component")
     @Deprecated
@@ -452,7 +448,6 @@ public class RestServer {
 
     @Path("/runtime/model/components/properties")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Changes multiple property value(s) of a runtime component(s) (propertyMap – see JSON objects)")
     public String setRuntimeComponentProperties(String bodyContent) {
@@ -492,7 +487,6 @@ public class RestServer {
 
     @Path("/runtime/model/components/properties")
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Changes multiple property value(s) of a runtime component(s) (propertyMap – see JSON objects)")
     @Deprecated
@@ -876,7 +870,6 @@ public class RestServer {
 
     @Path("/storage/models/{filepath}")
     @POST
-    @Consumes(MediaType.TEXT_XML)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Stores a model (XML body parameter) at the given filepath.")
     public String storeModel(@PathParam("filepath") String filepath, String modelInXML) {
@@ -904,7 +897,6 @@ public class RestServer {
 
     @Path("/storage/data/{filepath}")
     @POST
-    @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Stores data (body parameter) to a given filepath in the ARE/data folder")
     public String storeData(@PathParam("filepath") String filepath, String data) {
@@ -931,7 +923,6 @@ public class RestServer {
 
     @Path("/storage/webapps/{webappName}/{filepath}")
     @POST
-    @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Stores data (body parameter) for a specific webapp.")
     public String storeWebappData(@PathParam("webappName") String webappName, @PathParam("filepath") String filepath, String data) {
@@ -1083,7 +1074,6 @@ public class RestServer {
 
     @Path("/runtime/model/components/{componentId}/ports/{portId}/data")
     @POST
-    @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Sends data to a specific port of a component in the running model")
     public String sendDataToInputPort(String value, @PathParam("componentId") String componentId, @PathParam("portId") String portId) {
@@ -1109,7 +1099,6 @@ public class RestServer {
 
     @Path("/runtime/model/components/{componentId}/ports/{portId}/data")
     @PUT
-    @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Sends data to a specific port of a component in the running model")
     @Deprecated

--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java
@@ -90,6 +90,19 @@ public class RestServer {
         return JSONresponse;
     }
 
+    @Path("/restfunctions/withdeprecated")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Description("Returns a list with all the available rest functions including deprecated methods")
+    public String getRestFunctionsWithDeprecated() {
+        String JSONresponse = ObjectTransformation.objectToJSON(ServerRepository.getInstance().createListOfRestFunctions(true));
+        if (JSONresponse.equals("")) {
+            JSONresponse = "{'error':'Could not retrieve the rest function signatures (Object serialization failure)'}";
+        }
+
+        return JSONresponse;
+    }
+
     /**********************
      * Runtime resources
      **********************/
@@ -114,7 +127,7 @@ public class RestServer {
     }
 
     @Path("/runtime/model")
-    @PUT
+    @POST
     @Consumes(MediaType.TEXT_XML)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Deploys the model given as XML body parameter")
@@ -134,8 +147,18 @@ public class RestServer {
         return response;
     }
 
-    @Path("/runtime/model/{filepath}")
+    @Path("/runtime/model")
     @PUT
+    @Consumes(MediaType.TEXT_XML)
+    @Produces(MediaType.TEXT_PLAIN)
+    @Description("Deploys the model given as XML body parameter")
+    @Deprecated
+    public String deployModelPut(String modelInXML) {
+        return deployModel(modelInXML);
+    }
+
+    @Path("/runtime/model/{filepath}")
+    @POST
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Deploys the model located at {filepath}.")
     public String deployFile(@PathParam("filepath") String filepath) {
@@ -157,8 +180,17 @@ public class RestServer {
         return response;
     }
 
-    @Path("/runtime/model/state/{state}")
+    @Path("/runtime/model/{filepath}")
     @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    @Description("Deploys the model located at {filepath}.")
+    @Deprecated
+    public String deployFilePut(@PathParam("filepath") String filepath) {
+        return deployFile(filepath);
+    }
+
+    @Path("/runtime/model/state/{state}")
+    @POST
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Changes the state of the deployed model to STARTED, PAUSED, STOPPED")
     public String runModel(@PathParam("state") String state) {
@@ -200,6 +232,15 @@ public class RestServer {
         return response;
     }
 
+    @Path("/runtime/model/state/{state}")
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    @Description("Changes the state of the deployed model to STARTED, PAUSED, STOPPED")
+    @Deprecated
+    public String runModelPut(@PathParam("state") String state) {
+        return runModel(state);
+    }
+
     @Path("/runtime/model/state")
     @GET
     @Produces(MediaType.TEXT_PLAIN)
@@ -239,7 +280,7 @@ public class RestServer {
     }
 
     @Path("/runtime/model/autorun/{filepath}")
-    @PUT
+    @POST
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Deploys and starts the model of the given filepath")
     public String autorun(@PathParam("filepath") String filepath) {
@@ -259,6 +300,15 @@ public class RestServer {
         }
 
         return response;
+    }
+
+    @Path("/runtime/model/autorun/{filepath}")
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    @Description("Deploys and starts the model of the given filepath")
+    @Deprecated
+    public String autorunPut(@PathParam("filepath") String filepath) {
+        return autorun(filepath);
     }
 
     @Path("/runtime/model/components/ids")
@@ -360,7 +410,7 @@ public class RestServer {
     }
 
     @Path("/runtime/model/components/{componentId}/{propertyKey}")
-    @PUT
+    @POST
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Changes a property value of a model component")
@@ -382,8 +432,18 @@ public class RestServer {
         return response;
     }
 
-    @Path("/runtime/model/components/properties")
+    @Path("/runtime/model/components/{componentId}/{propertyKey}")
     @PUT
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    @Description("Changes a property value of a model component")
+    @Deprecated
+    public String setRuntimeComponentPropertyPut(String value, @PathParam("componentId") String componentId, @PathParam("propertyKey") String propertyKey) {
+        return setRuntimeComponentProperty(value, componentId, propertyKey);
+    }
+
+    @Path("/runtime/model/components/properties")
+    @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Changes multiple property value(s) of a runtime component(s) (propertyMap – see JSON objects)")
@@ -420,6 +480,16 @@ public class RestServer {
         } catch (Exception ex) {
             return "";
         }
+    }
+
+    @Path("/runtime/model/components/properties")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    @Description("Changes multiple property value(s) of a runtime component(s) (propertyMap – see JSON objects)")
+    @Deprecated
+    public String setRuntimeComponentPropertiesPut(String bodyContent) {
+        return setRuntimeComponentProperties(bodyContent);
     }
 
     @Path("/runtime/model/components/{componentId}/ports/input/ids")
@@ -1004,7 +1074,7 @@ public class RestServer {
     }
 
     @Path("/runtime/model/components/{componentId}/ports/{portId}/data")
-    @PUT
+    @POST
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Sends data to a specific port of a component in the running model")
@@ -1029,6 +1099,16 @@ public class RestServer {
         return response;
     }
 
+    @Path("/runtime/model/components/{componentId}/ports/{portId}/data")
+    @PUT
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    @Description("Sends data to a specific port of a component in the running model")
+    @Deprecated
+    public String sendDataToInputPortPut(String value, @PathParam("componentId") String componentId, @PathParam("portId") String portId) {
+        return sendDataToInputPort(value, componentId, portId);
+    }
+
     /**
      * this method is the same as sendDataToInputPort(), but with HTTP GET for compatibility reasons for clients which do not support HTTP PUT
      */
@@ -1043,7 +1123,7 @@ public class RestServer {
     }
 
     @Path("/runtime/model/components/{componentId}/events/{eventId}")
-    @PUT
+    @POST
     @Produces(MediaType.TEXT_PLAIN)
     @Description("Triggers an event on the given component/port")
     public String triggerEvent(@PathParam("componentId") String componentId, @PathParam("eventId") String eventId) {
@@ -1067,5 +1147,14 @@ public class RestServer {
         }
 
         return response;
+    }
+
+    @Path("/runtime/model/components/{componentId}/events/{eventId}")
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    @Description("Triggers an event on the given component/port")
+    @Deprecated
+    public String triggerEventPut(@PathParam("componentId") String componentId, @PathParam("eventId") String eventId) {
+        return triggerEvent(componentId, eventId);
     }
 }

--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java
@@ -79,7 +79,7 @@ public class RestServer {
 
     @Path("/version")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
     @Description("Returns the current ARE version")
     public String getVersion() {
         return "#{APPLICATION_VERSION_NUMBER}#";

--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/serverUtils/RestFunction.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/serverUtils/RestFunction.java
@@ -1,26 +1,26 @@
 /*
  *    AsTeRICS - Assistive Technology Rapid Integration and Construction Set
- * 
- * 
- *        d8888      88888888888       8888888b.  8888888 .d8888b.   .d8888b. 
+ *
+ *
+ *        d8888      88888888888       8888888b.  8888888 .d8888b.   .d8888b.
  *       d88888          888           888   Y88b   888  d88P  Y88b d88P  Y88b
- *      d88P888          888           888    888   888  888    888 Y88b.     
- *     d88P 888 .d8888b  888   .d88b.  888   d88P   888  888         "Y888b.  
+ *      d88P888          888           888    888   888  888    888 Y88b.
+ *     d88P 888 .d8888b  888   .d88b.  888   d88P   888  888         "Y888b.
  *    d88P  888 88K      888  d8P  Y8b 8888888P"    888  888            "Y88b.
  *   d88P   888 "Y8888b. 888  88888888 888 T88b     888  888    888       "888
  *  d8888888888      X88 888  Y8b.     888  T88b    888  Y88b  d88P Y88b  d88P
- * d88P     888  88888P' 888   "Y8888  888   T88b 8888888 "Y8888P"   "Y8888P" 
+ * d88P     888  88888P' 888   "Y8888  888   T88b 8888888 "Y8888P"   "Y8888P"
  *
  *
- *                    homepage: http://www.asterics.org 
+ *                    homepage: http://www.asterics.org
  *
- *         This project has been funded by the European Commission, 
+ *         This project has been funded by the European Commission,
  *                      Grant Agreement Number 247730
- *  
- *  
+ *
+ *
  *         Dual License: MIT or GPL v3.0 with "CLASSPATH" exception
  *         (please refer to the folder LICENSE)
- * 
+ *
  */
 
 package eu.asterics.mw.webservice.serverUtils;
@@ -35,9 +35,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * This class is just a container that holds the information describing a restfull function.
- * 
+ *
  * It contains data like the HTTP Type of a function (GET, POST, PUT...), the resource path (storage/model/...), the parameters required etc.
- * 
+ *
  * @author Marios Komodromos (mkomod05@cs.ucy.ac.cy)
  *
  */
@@ -47,7 +47,7 @@ public class RestFunction {
 
     /**
      * This annotation is used to describe the meaning of a REST function.
-     * 
+     *
      * @author mad <deinhofe@technikum-wien.at>
      * @date Apr 15, 2019
      *
@@ -63,7 +63,7 @@ public class RestFunction {
     private String produces;
     private String bodyParameter;
     private String description;
-    private boolean isDeprecated;
+    private boolean deprecated;
 
     public RestFunction() {
         this.httpRequestType = "";
@@ -72,17 +72,17 @@ public class RestFunction {
         this.produces = "";
         this.bodyParameter = "";
         this.description = "";
-        this.isDeprecated = false;
+        this.deprecated = false;
     }
 
-    public RestFunction(String httpRequestType, String path, String consumes, String produces, String bodyParameter, String description) {
+    public RestFunction(String httpRequestType, String path, String consumes, String produces, String bodyParameter, String description, boolean deprecated) {
         this.httpRequestType = httpRequestType;
         this.path = path;
         this.consumes = consumes;
         this.produces = produces;
         this.bodyParameter = bodyParameter;
         this.description = description;
-        this.isDeprecated = false;
+        this.deprecated = deprecated;
     }
 
     public String getHttpRequestType() {
@@ -133,11 +133,11 @@ public class RestFunction {
         this.description = description;
     }
 
-    public boolean isDeprecated() {
-        return this.isDeprecated;
+    public boolean getDeprecated() {
+        return this.deprecated;
     }
 
     public void setDeprecated(boolean deprecated) {
-        this.isDeprecated = deprecated;
+        this.deprecated = deprecated;
     }
 }

--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/serverUtils/RestFunction.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/serverUtils/RestFunction.java
@@ -63,6 +63,7 @@ public class RestFunction {
     private String produces;
     private String bodyParameter;
     private String description;
+    private boolean isDeprecated;
 
     public RestFunction() {
         this.httpRequestType = "";
@@ -71,6 +72,7 @@ public class RestFunction {
         this.produces = "";
         this.bodyParameter = "";
         this.description = "";
+        this.isDeprecated = false;
     }
 
     public RestFunction(String httpRequestType, String path, String consumes, String produces, String bodyParameter, String description) {
@@ -80,6 +82,7 @@ public class RestFunction {
         this.produces = produces;
         this.bodyParameter = bodyParameter;
         this.description = description;
+        this.isDeprecated = false;
     }
 
     public String getHttpRequestType() {
@@ -130,4 +133,11 @@ public class RestFunction {
         this.description = description;
     }
 
+    public boolean isDeprecated() {
+        return this.isDeprecated;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+        this.isDeprecated = deprecated;
+    }
 }

--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/serverUtils/ServerRepository.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/serverUtils/ServerRepository.java
@@ -300,7 +300,7 @@ public class ServerRepository {
                     // If there is not @Path or no @HTTRequestType it cannot be a REST function, so skip it.
                     continue;
                 }
-                if (!restFunction.isDeprecated() || includeDeprecated) {
+                if (!restFunction.getDeprecated() || includeDeprecated) {
                     restFunctions.add(restFunction);
                 }
             }

--- a/ARE_RestAPIlibraries/JavaLibrary/src/eu/asterics/rest/javaClient/ARECommunicator.java
+++ b/ARE_RestAPIlibraries/JavaLibrary/src/eu/asterics/rest/javaClient/ARECommunicator.java
@@ -80,7 +80,7 @@ public class ARECommunicator {
 	 */
 	public String uploadModel(String modelInXML) throws Exception {
 		try {
-			HttpResponse httpResponse = httpCommunicator.putRequest("/runtime/model",
+			HttpResponse httpResponse = httpCommunicator.postRequest("/runtime/model",
 					HttpCommunicator.DATATYPE_TEXT_XML, HttpCommunicator.DATATYPE_TEXT_PLAIN,
 					modelInXML);
 			return httpResponse.getBody();
@@ -101,7 +101,7 @@ public class ARECommunicator {
 	public String autorun(String filepath) throws Exception {
 		try {
 			String encodedFilepath = astericsAPIEncoding.encodeString(filepath);
-			HttpResponse httpResponse = httpCommunicator.putRequest("/runtime/model/autorun/" + encodedFilepath,
+			HttpResponse httpResponse = httpCommunicator.postRequest("/runtime/model/autorun/" + encodedFilepath,
 					HttpCommunicator.DATATYPE_TEXT_PLAIN);
 			return httpResponse.getBody();
 		} catch (Exception e) {
@@ -117,7 +117,7 @@ public class ARECommunicator {
 	 */
 	public String pauseModel() throws Exception {
 		try {
-			HttpResponse httpResponse = httpCommunicator.putRequest("/runtime/model/state/pause",
+			HttpResponse httpResponse = httpCommunicator.postRequest("/runtime/model/state/pause",
 					HttpCommunicator.DATATYPE_TEXT_PLAIN);
 			return httpResponse.getBody();
 		} catch (Exception e) {
@@ -133,7 +133,7 @@ public class ARECommunicator {
 	 */
 	public String startModel() throws Exception {
 		try {
-			HttpResponse httpResponse = httpCommunicator.putRequest("/runtime/model/state/start",
+			HttpResponse httpResponse = httpCommunicator.postRequest("/runtime/model/state/start",
 					HttpCommunicator.DATATYPE_TEXT_PLAIN);
 			return httpResponse.getBody();
 		} catch (Exception e) {
@@ -149,7 +149,7 @@ public class ARECommunicator {
 	 */
 	public String stopModel() throws Exception {
 		try {
-			HttpResponse httpResponse = httpCommunicator.putRequest("/runtime/model/state/stop",
+			HttpResponse httpResponse = httpCommunicator.postRequest("/runtime/model/state/stop",
 					HttpCommunicator.DATATYPE_TEXT_PLAIN);
 			return httpResponse.getBody();
 		} catch (Exception e) {
@@ -265,7 +265,7 @@ public class ARECommunicator {
 	public String deployModelFromFile(String filepath) throws Exception {
 		try {
 			String encodedFilepath = astericsAPIEncoding.encodeString(filepath);
-			HttpResponse httpResponse = httpCommunicator.putRequest("/runtime/model/" + encodedFilepath,
+			HttpResponse httpResponse = httpCommunicator.postRequest("/runtime/model/" + encodedFilepath,
 					HttpCommunicator.DATATYPE_TEXT_PLAIN);
 			return httpResponse.getBody();
 		} catch (Exception e) {
@@ -413,7 +413,7 @@ public class ARECommunicator {
 		try {
 			String encodedId = astericsAPIEncoding.encodeString(componentId);
 			String encodedKey = astericsAPIEncoding.encodeString(propertyKey);
-			HttpResponse httpResponse = httpCommunicator.putRequest("/runtime/model/components/"+encodedId+"/"+encodedKey,
+			HttpResponse httpResponse = httpCommunicator.postRequest("/runtime/model/components/"+encodedId+"/"+encodedKey,
 					HttpCommunicator.DATATYPE_TEXT_PLAIN, HttpCommunicator.DATATYPE_TEXT_PLAIN,
 					value);
 			return httpResponse.getBody();
@@ -435,7 +435,7 @@ public class ARECommunicator {
 		String encodedId = astericsAPIEncoding.encodeString(componentId);
 		String encodedPortId = astericsAPIEncoding.encodeString(portId);
 		String url = MessageFormat.format("/runtime/model/components/{0}/ports/{1}/data", encodedId, encodedPortId);
-		HttpResponse httpResponse = httpCommunicator.putRequest(url,
+		HttpResponse httpResponse = httpCommunicator.postRequest(url,
 				HttpCommunicator.DATATYPE_TEXT_PLAIN, HttpCommunicator.DATATYPE_TEXT_PLAIN,
 				value);
 		return httpResponse != null ? httpResponse.getBody() : null;
@@ -453,7 +453,7 @@ public class ARECommunicator {
 		String encodedId = astericsAPIEncoding.encodeString(componentId);
 		String encodedPortId = astericsAPIEncoding.encodeString(eventPortId);
 		String url = MessageFormat.format("/runtime/model/components/{0}/events/{1}", encodedId, encodedPortId);
-		HttpResponse httpResponse = httpCommunicator.putRequest(url,
+		HttpResponse httpResponse = httpCommunicator.postRequest(url,
 				HttpCommunicator.DATATYPE_TEXT_PLAIN);
 		return httpResponse != null ? httpResponse.getBody() : null;
 	}

--- a/ARE_RestAPIlibraries/JavaLibrary/src/eu/asterics/rest/javaClient/serialization/RestFunction.java
+++ b/ARE_RestAPIlibraries/JavaLibrary/src/eu/asterics/rest/javaClient/serialization/RestFunction.java
@@ -1,20 +1,70 @@
+/*
+ *    AsTeRICS - Assistive Technology Rapid Integration and Construction Set
+ *
+ *
+ *        d8888      88888888888       8888888b.  8888888 .d8888b.   .d8888b.
+ *       d88888          888           888   Y88b   888  d88P  Y88b d88P  Y88b
+ *      d88P888          888           888    888   888  888    888 Y88b.
+ *     d88P 888 .d8888b  888   .d88b.  888   d88P   888  888         "Y888b.
+ *    d88P  888 88K      888  d8P  Y8b 8888888P"    888  888            "Y88b.
+ *   d88P   888 "Y8888b. 888  88888888 888 T88b     888  888    888       "888
+ *  d8888888888      X88 888  Y8b.     888  T88b    888  Y88b  d88P Y88b  d88P
+ * d88P     888  88888P' 888   "Y8888  888   T88b 8888888 "Y8888P"   "Y8888P"
+ *
+ *
+ *                    homepage: http://www.asterics.org
+ *
+ *         This project has been funded by the European Commission,
+ *                      Grant Agreement Number 247730
+ *
+ *
+ *         Dual License: MIT or GPL v3.0 with "CLASSPATH" exception
+ *         (please refer to the folder LICENSE)
+ *
+ */
+
 package eu.asterics.rest.javaClient.serialization;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
+/**
+ * This class is just a container that holds the information describing a restfull function.
+ *
+ * It contains data like the HTTP Type of a function (GET, POST, PUT...), the resource path (storage/model/...), the parameters required etc.
+ *
+ * @author Marios Komodromos (mkomod05@cs.ucy.ac.cy)
+ *
+ */
 @XmlRootElement()
 @XmlAccessorType(XmlAccessType.FIELD)
 public class RestFunction {
+
+	/**
+	 * This annotation is used to describe the meaning of a REST function.
+	 *
+	 * @author mad <deinhofe@technikum-wien.at>
+	 * @date Apr 15, 2019
+	 *
+	 */
+	@Retention(RUNTIME)
+	public @interface Description {
+		String value() default "";
+	}
+
 	private String httpRequestType;
 	private String path;
 	private String consumes;
 	private String produces;
 	private String bodyParameter;
 	private String description;
-	
-	
+	private boolean deprecated;
+
 	public RestFunction() {
 		this.httpRequestType = "";
 		this.path = "";
@@ -22,65 +72,72 @@ public class RestFunction {
 		this.produces = "";
 		this.bodyParameter = "";
 		this.description = "";
+		this.deprecated = false;
 	}
-	
-	public RestFunction(String httpRequestType, String path, String consumes,
-			String produces, String bodyParameter, String description) {
+
+	public RestFunction(String httpRequestType, String path, String consumes, String produces, String bodyParameter, String description, boolean deprecated) {
 		this.httpRequestType = httpRequestType;
 		this.path = path;
 		this.consumes = consumes;
 		this.produces = produces;
 		this.bodyParameter = bodyParameter;
 		this.description = description;
+		this.deprecated = false;
 	}
-
 
 	public String getHttpRequestType() {
 		return httpRequestType;
 	}
-	
+
 	public void setHttpRequestType(String httpRequestType) {
 		this.httpRequestType = httpRequestType;
 	}
-	
+
 	public String getPath() {
 		return path;
 	}
-	
+
 	public void setPath(String path) {
 		this.path = path;
 	}
-	
+
 	public String getConsumes() {
 		return consumes;
 	}
-	
+
 	public void setConsumes(String consumes) {
 		this.consumes = consumes;
 	}
-	
+
 	public String getProduces() {
 		return produces;
 	}
-	
+
 	public void setProduces(String produces) {
 		this.produces = produces;
 	}
-	
+
 	public String getBodyParameter() {
 		return bodyParameter;
 	}
-	
+
 	public void setBodyParameter(String bodyParameter) {
 		this.bodyParameter = bodyParameter;
 	}
-	
+
 	public String getDescription() {
 		return description;
 	}
-	
+
 	public void setDescription(String description) {
 		this.description = description;
 	}
-	
+
+	public boolean getDeprecated() {
+		return this.deprecated;
+	}
+
+	public void setDeprecated(boolean deprecated) {
+		this.deprecated = deprecated;
+	}
 }

--- a/ARE_RestAPIlibraries/clientExample/javascript/areCommunicator.js
+++ b/ARE_RestAPIlibraries/clientExample/javascript/areCommunicator.js
@@ -70,7 +70,7 @@ function uploadModel(successCallback, errorCallback, modelInXML) {
   if (modelInXML == "") return;
 
   $.ajax({
-    type: "PUT",
+    type: "POST",
     url: _baseURI + "runtime/model",
     contentType: "text/xml", //content-type of the request
     data: modelInXML,
@@ -89,7 +89,7 @@ function autorun(successCallback, errorCallback, filepath) {
   if (filepath == "") return;
 
   $.ajax({
-    type: "PUT",
+    type: "POST",
     url: _baseURI + "runtime/model/autorun/" + encodeParam(filepath),
     datatype: "text",
     crossDomain: true,
@@ -104,7 +104,7 @@ function autorun(successCallback, errorCallback, filepath) {
 
 function pauseModel(successCallback, errorCallback) {
   $.ajax({
-    type: "PUT",
+    type: "POST",
     url: _baseURI + "runtime/model/state/pause",
     datatype: "text",
     crossDomain: true,
@@ -119,7 +119,7 @@ function pauseModel(successCallback, errorCallback) {
 
 function startModel(successCallback, errorCallback) {
   $.ajax({
-    type: "PUT",
+    type: "POST",
     url: _baseURI + "runtime/model/state/start",
     datatype: "text",
     crossDomain: true,
@@ -134,7 +134,7 @@ function startModel(successCallback, errorCallback) {
 
 function stopModel(successCallback, errorCallback) {
   $.ajax({
-    type: "PUT",
+    type: "POST",
     url: _baseURI + "runtime/model/state/stop",
     datatype: "text",
     crossDomain: true,
@@ -181,7 +181,7 @@ function deployModelFromFile(successCallback, errorCallback, filepath) {
   if (filepath == "") return;
 
   $.ajax({
-    type: "PUT",
+    type: "POST",
     url: _baseURI + "runtime/model/" + encodeParam(filepath),
     datatype: "text",
     crossDomain: true,
@@ -295,7 +295,7 @@ function setRuntimeComponentProperties(
   if (propertyMap == "") return;
 
   $.ajax({
-    type: "PUT",
+    type: "POST",
     url: _baseURI + "runtime/model/components/properties",
     contentType: "application/json",
     data: propertyMap,
@@ -320,7 +320,7 @@ function setRuntimeComponentProperty(
   if (componentId == "" || propertyKey == "" || componentValue == "") return;
 
   $.ajax({
-    type: "PUT",
+    type: "POST",
     url:
       _baseURI +
       "runtime/model/components/" +
@@ -594,7 +594,7 @@ function sendDataToInputPort(
   if (!componentId || !portId || !value) return;
 
   $.ajax({
-    type: "PUT",
+    type: "POST",
     beforeSend: function(request) {
       request.setRequestHeader("Content-Type", "text/plain");
     },
@@ -627,7 +627,7 @@ function triggerEvent(
   if (!componentId || !eventPortId) return;
 
   $.ajax({
-    type: "PUT",
+    type: "POST",
     url:
       _baseURI +
       "runtime/model/components/" +

--- a/build.xml
+++ b/build.xml
@@ -119,6 +119,7 @@
 		<replace file="./Installer/asterics-are/package/linux/control" token="#{APPLICATION_VERSION_NUMBER}#" value="${app_version_number}"/>
 		<replace file="./Installer/asterics-are/APE.properties" token="#{APPLICATION_VERSION_NUMBER}#" value="${app_version_number}"/>
 		<replace file="./ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java" token="#{APPLICATION_VERSION_NUMBER}#" value="${app_version_number}"/>
+		<replace file="./ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/RestServer.java" token="#{APPLICATION_VERSION_NUMBER}#" value="${app_version_number}"/>
 	</target>
 	
 	<scriptdef name="getversionnumber" language="javascript">


### PR DESCRIPTION
Because of problems with HTTP PUT requests in Firefox (see https://bugzilla.mozilla.org/show_bug.cgi?id=1376310 ) we decided to change all PUT requests of our REST API to HTTP POST requests, which are "simple requests" and therefore fix the problem of Firefox (see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests ).

DONE:
* All PUT Requests from `RestServer.java` are now POST
* PUT requests are still valid, but deprecated
* the path `rest/restfunctions` returns actions only the POST actions, not the PUT actions anymore
* the path `rest/restfunctions/withdeprecated` returns all actions, including the deprecated PUT functions
* `areCommunicator.js` --> changed everything to POST
* `ARECommunicator.java` --> changed everything to POST

TODO/OPEN:
* what to do with `areCommunicator.js` in WebACS? also change it now? But it could lead to incompatibilities with older ARE versions.
* I did not manage to run `eu.asterics.rest.javaClient.tester.JavaClient.java` -> how to run it?