### PR TITLE
Deinhofer/resolve port conflicts

### DIFF
--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/AREProperties.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/AREProperties.java
@@ -53,6 +53,10 @@ public class AREProperties extends Properties {
     public static final String ARE_WEBSERVICE_SSL_PORT_REST_KEY = "ARE.webservice.ssl.port.REST";
     public static final String ARE_WEBSERVICE_SSL_PORT_WEBSOCKET_KEY = "ARE.webservice.ssl.port.websocket";
 
+    //Port conflict resolving
+    public static final String ARE_PORT_CONFLICT_NR_TRIES_KEY = "ARE.port.conflict.nr.tries";
+    public static final String ARE_PORT_CONFLICT_STEP_SIZE_KEY = "ARE.port.conflict.step.size";
+
     private AREProperties() {
         logger = AstericsErrorHandling.instance.getLogger();
         try {

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/UDP/UDPServer.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/UDP/UDPServer.java
@@ -55,53 +55,64 @@ public class UDPServer {
      * @param args
      */
     public void start() {
-        DatagramSocket udpServer = null;
-        int listenerPort = 9091; // UPD Listener port
-        int callbackPort = 9092; // UDP Message return port
-        byte[] receiveUdp = new byte[32]; // Size of incoming datagrmm, formerly
-                                          // 256
-        byte[] sendUdp = new byte[128]; // Size of outgoing datagramm, formerly
-                                        // 256
 
-        try {
-            udpServer = new DatagramSocket(listenerPort);
-            logger.fine("UDPServer is ready to receive data...");
+        int NR_TRIES_PORT=3;
+        int PORT_STEP_SIZE=5;
+        boolean success=false;
 
-            while (true) {
-                DatagramPacket receivedPacket = new DatagramPacket(receiveUdp, receiveUdp.length);
-                udpServer.receive(receivedPacket);
+        for(int i=0;i<NR_TRIES_PORT && !success;i++) {
 
-                String receivedStr = new String(receivedPacket.getData());
-                logger.fine("Received UPD data:" + receivedStr);
+            DatagramSocket udpServer = null;
+            int listenerPort = 9091+i*PORT_STEP_SIZE; // UPD Listener port
+            int callbackPort = 9092; // UDP Message return port
+            byte[] receiveUdp = new byte[32]; // Size of incoming datagrmm, formerly
+                                            // 256
+            byte[] sendUdp = new byte[128]; // Size of outgoing datagramm, formerly
+                                            // 256
 
-                // If the right string being received, the thread waits to give
-                // the sender enough time
-                // to close the sending port socket and open the receiving port
-                // socket.
-                if (receivedStr.contains("AsTeRICS Broadcast")) {
-                    Thread.sleep(200);
-                    InetAddress IPSender = receivedPacket.getAddress();
+            try {
+                udpServer = new DatagramSocket(listenerPort);
+                success=true;
+                logger.fine("UDPServer is ready to receive data...");
 
-                    String hostname = InetAddress.getLocalHost().getHostName();
-                    String ip = InetAddress.getLocalHost().getHostAddress();
+                while (true) {
+                    DatagramPacket receivedPacket = new DatagramPacket(receiveUdp, receiveUdp.length);
+                    udpServer.receive(receivedPacket);
 
-                    // sending the hostname and the host IP
-                    sendUdp = ("AsTeRICS Broadcast Ret, Hostname:" + hostname + " IP:" + ip).getBytes();
-                    DatagramPacket sendPacket = new DatagramPacket(sendUdp, sendUdp.length, IPSender, callbackPort);
-                    udpServer.send(sendPacket);
-                    logger.fine("Sended UPD data to ACS:" + new String(sendUdp));
+                    String receivedStr = new String(receivedPacket.getData());
+                    logger.fine("Received UPD data:" + receivedStr);
+
+                    // If the right string being received, the thread waits to give
+                    // the sender enough time
+                    // to close the sending port socket and open the receiving port
+                    // socket.
+                    if (receivedStr.contains("AsTeRICS Broadcast")) {
+                        Thread.sleep(200);
+                        InetAddress IPSender = receivedPacket.getAddress();
+
+                        String hostname = InetAddress.getLocalHost().getHostName();
+                        String ip = InetAddress.getLocalHost().getHostAddress();
+
+                        // sending the hostname and the host IP
+                        sendUdp = ("AsTeRICS Broadcast Ret, Hostname:" + hostname + " IP:" + ip).getBytes();
+                        DatagramPacket sendPacket = new DatagramPacket(sendUdp, sendUdp.length, IPSender, callbackPort);
+                        udpServer.send(sendPacket);
+                        logger.fine("Sended UPD data to ACS:" + new String(sendUdp));
+                    }
+                }
+            } catch (SocketException e) {
+                logger.warning(this.getClass().getName() + "." + "SocketException in UDPServer-> \n" + e.getMessage());
+            } catch (UnknownHostException e) {
+                logger.warning(this.getClass().getName() + "." + "UnknownHostException in UDPServer-> \n" + e.getMessage());
+            } catch (IOException e) {
+                logger.warning(this.getClass().getName() + "." + "IOException in UDPServer-> \n" + e.getMessage());
+            } catch (InterruptedException e) {
+                logger.warning(this.getClass().getName() + "." + "InterruptedException in UDPServer-> \n" + e.getMessage());
+            } finally {
+                if (udpServer != null) {
+                    udpServer.close();
                 }
             }
-        } catch (SocketException e) {
-            logger.warning(this.getClass().getName() + "." + "SocketException in UDPServer-> \n" + e.getMessage());
-        } catch (UnknownHostException e) {
-            logger.warning(this.getClass().getName() + "." + "UnknownHostException in UDPServer-> \n" + e.getMessage());
-        } catch (IOException e) {
-            logger.warning(this.getClass().getName() + "." + "IOException in UDPServer-> \n" + e.getMessage());
-        } catch (InterruptedException e) {
-            logger.warning(this.getClass().getName() + "." + "InterruptedException in UDPServer-> \n" + e.getMessage());
-        } finally {
-            udpServer.close();
         }
 
     }

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/UDP/UDPServer.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/UDP/UDPServer.java
@@ -30,9 +30,13 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
-import java.util.logging.Logger;
+import java.util.logging.*;
 
 import eu.asterics.mw.services.AstericsErrorHandling;
+
+import eu.asterics.mw.are.AREProperties;
+import static eu.asterics.mw.are.AREProperties.*;
+
 
 /**
  * This class implements the UDPServer. The UDPServer is listening to an UDP
@@ -60,6 +64,19 @@ public class UDPServer {
         int PORT_STEP_SIZE=5;
         boolean success=false;
 
+        try {
+            NR_TRIES_PORT = Integer.parseInt(AREProperties.instance.getProperty(ARE_PORT_CONFLICT_NR_TRIES_KEY));
+        } catch (NumberFormatException e) {
+            AstericsErrorHandling.instance.getLogger().logp(Level.WARNING, this.getClass().getName(), "ServerRepository()",
+                    "Configured value for "+ARE_PORT_CONFLICT_NR_TRIES_KEY+" not numeric: " + e.getMessage(), e);
+        }
+        try {
+            PORT_STEP_SIZE = Integer.parseInt(AREProperties.instance.getProperty(ARE_PORT_CONFLICT_STEP_SIZE_KEY));
+        } catch (NumberFormatException e) {
+            AstericsErrorHandling.instance.getLogger().logp(Level.WARNING, this.getClass().getName(), "ServerRepository()",
+                    "Configured value for "+ARE_PORT_CONFLICT_STEP_SIZE_KEY+" not numeric: " + e.getMessage(), e);
+        }
+
         for(int i=0;i<NR_TRIES_PORT && !success;i++) {
 
             DatagramSocket udpServer = null;
@@ -73,7 +90,7 @@ public class UDPServer {
             try {
                 udpServer = new DatagramSocket(listenerPort);
                 success=true;
-                logger.fine("UDPServer is ready to receive data...");
+                logger.fine("UDPServer [:"+listenerPort+"] is ready to receive data...");
 
                 while (true) {
                     DatagramPacket receivedPacket = new DatagramPacket(receiveUdp, receiveUdp.length);

--- a/ARE/middleware/src/main/java/eu/asterics/mw/are/asapi/Activator.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/are/asapi/Activator.java
@@ -25,7 +25,7 @@
 
 package eu.asterics.mw.are.asapi;
 
-import java.util.logging.Logger;
+import java.util.logging.*;
 
 import org.apache.thrift.server.TServer;
 import org.apache.thrift.server.TThreadPoolServer;
@@ -33,6 +33,8 @@ import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TServerTransport;
 
 import eu.asterics.mw.are.AREProperties;
+import static eu.asterics.mw.are.AREProperties.*;
+
 import eu.asterics.mw.services.*;
 
 public class Activator implements Runnable {
@@ -60,6 +62,20 @@ public class Activator implements Runnable {
     public Activator() {
         int NR_TRIES_PORT=3;
         int PORT_STEP_SIZE=5;
+
+        try {
+            NR_TRIES_PORT = Integer.parseInt(AREProperties.instance.getProperty(ARE_PORT_CONFLICT_NR_TRIES_KEY));
+        } catch (NumberFormatException e) {
+            AstericsErrorHandling.instance.getLogger().logp(Level.WARNING, this.getClass().getName(), "ServerRepository()",
+                    "Configured value for "+ARE_PORT_CONFLICT_NR_TRIES_KEY+" not numeric: " + e.getMessage(), e);
+        }
+        try {
+            PORT_STEP_SIZE = Integer.parseInt(AREProperties.instance.getProperty(ARE_PORT_CONFLICT_STEP_SIZE_KEY));
+        } catch (NumberFormatException e) {
+            AstericsErrorHandling.instance.getLogger().logp(Level.WARNING, this.getClass().getName(), "ServerRepository()",
+                    "Configured value for "+ARE_PORT_CONFLICT_STEP_SIZE_KEY+" not numeric: " + e.getMessage(), e);
+        }
+
         for(int i=0;i<NR_TRIES_PORT;i++) {
             try {
                 logger = AstericsErrorHandling.instance.getLogger();

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/AstericsGUI.java
@@ -236,8 +236,9 @@ public class AstericsGUI implements IAREEventListener {
                 // ignore, in this case don't show name.
             }
         }
+        String portString=" [:"+AREServices.instance.getRESTPort()+",:"+AREServices.instance.getACSPort()+"]";
         String versionString = "AsTeRICS ARE " + ARE_VERSION;
-        String title = modelName != null ? modelName + " - " + versionString : versionString;
+        String title = modelName != null ? modelName + " - " + versionString+portString : versionString+portString;
         System.out.println(title);
         if (mainFrame != null) {
             mainFrame.setTitle(title);

--- a/ARE/middleware/src/main/java/eu/asterics/mw/gui/ControlPane.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/gui/ControlPane.java
@@ -274,7 +274,7 @@ public class ControlPane extends JPanel {
             globeLabel = new ControlPanelLabel(getFullURL(GLOBE_ICON_PATH), getFullURL(GLOBE_ICON_PATH_RO), "Open ARE Webserver Startpage") {
                 @Override
                 public void onMouseClick() {
-                    String url = MessageFormat.format("http://localhost:{0}/", AREProperties.instance.getProperty(ARE_WEBSERVICE_PORT_REST_KEY));
+                    String url = MessageFormat.format("http://localhost:{0}/", String.valueOf(AREServices.instance.getRESTPort()));
                     try {
                         OSUtils.openURL(url, OSUtils.OS_NAMES.ALL);
                     } catch (IOException e) {

--- a/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
+++ b/ARE/middleware/src/main/java/eu/asterics/mw/services/AREServices.java
@@ -115,8 +115,11 @@ import eu.asterics.mw.utils.OSUtils;
 
 public class AREServices implements IAREServices {
     public static final String WEB_ACS_EDIT_MODEL_URL_KEY = "WebACS.editModel.URL";
-    public static final String LOCAL_WEB_ACS_EDIT_MODEL_URL = "http://localhost:{0}/WebACS/index.html?autoConnect=true&autoDownloadModel=true";
-    public static final String ONLINE_WEB_ACS_EDIT_MODEL_URL = "https://webacs.asterics.eu/index.html?autoConnect=true&autoDownloadModel=true";
+    public static final String LOCAL_WEB_ACS_EDIT_MODEL_URL = "http://localhost:{0}/WebACS/index.html?autoConnect=true&autoDownloadModel=true&areBaseURI=http://127.0.0.1:{0}";
+    public static final String ONLINE_WEB_ACS_EDIT_MODEL_URL = "https://webacs.asterics.eu/index.html?autoConnect=true&autoDownloadModel=true&areBaseURI=http://127.0.0.1:{0}";
+
+    private int acsPort=9090;
+    private int restPort=8081;
 
     private final String STORAGE_FOLDER = "storage";
     private Logger logger = null;
@@ -486,12 +489,44 @@ public class AREServices implements IAREServices {
     public void editModel() {
         String url = AREProperties.instance.getProperty(WEB_ACS_EDIT_MODEL_URL_KEY);
         // If the url value contains {0} replace it with the currently configured REST port.
-        url = MessageFormat.format(url, AREProperties.instance.getProperty(ARE_WEBSERVICE_PORT_REST_KEY));
+        url = MessageFormat.format(url, String.valueOf(getRESTPort()));
         try {
             OSUtils.openURL(url, OSUtils.OS_NAMES.ALL);
         } catch (IOException e) {
             logger.log(Level.SEVERE, "error opening WebACS for current model.", e);
         }
+    }
+
+    /**
+     * Sets the successfully opened ACS port.
+     * @param acsPort
+     */
+    public void setACSPort(int acsPort) {
+        this.acsPort=acsPort;
+    }
+
+    /**
+     * Returns the successfully opened ACS port.
+     * @return
+     */
+    public int getACSPort() {
+        return acsPort;
+    }
+
+    /**
+     * Sets the successfully bound REST port.
+     * @param restPort
+     */
+    public void setRESTPort(int restPort) {
+        this.restPort=restPort;
+    }
+
+    /**
+     * Gets the successfully bound REST port.
+     * @return
+     */
+    public int getRESTPort() {
+        return restPort;
     }
 
     /**

--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/WebServiceEngine.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/WebServiceEngine.java
@@ -30,7 +30,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
+import java.util.logging.*;
 
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
@@ -48,6 +48,9 @@ import eu.asterics.mw.services.*;
 import eu.asterics.mw.services.ResourceRegistry;
 import eu.asterics.mw.services.ResourceRegistry.RES_TYPE;
 import eu.asterics.mw.webservice.serverUtils.ServerRepository;
+
+import eu.asterics.mw.are.*;
+import static eu.asterics.mw.are.AREProperties.*;
 
 /**
  * This class initializes the web services of the AsTeRICS framework. This includes an http-server, a REST interface and a websocket.
@@ -89,6 +92,23 @@ public class WebServiceEngine {
         int NR_TRIES_PORT=3;
         int PORT_STEP_SIZE=5;
         boolean success=false;
+
+        try {
+            AREProperties.instance.setDefaultPropertyValue(ARE_PORT_CONFLICT_NR_TRIES_KEY, String.valueOf(3),
+                    "The nr. of tries to use for automatic port resolving in case the port is already used by another program.");
+            NR_TRIES_PORT = Integer.parseInt(AREProperties.instance.getProperty(ARE_PORT_CONFLICT_NR_TRIES_KEY));
+        } catch (NumberFormatException e) {
+            AstericsErrorHandling.instance.getLogger().logp(Level.WARNING, this.getClass().getName(), "ServerRepository()",
+                    "Configured value for "+ARE_PORT_CONFLICT_NR_TRIES_KEY+" not numeric: " + e.getMessage(), e);
+        }
+        try {
+            AREProperties.instance.setDefaultPropertyValue(ARE_PORT_CONFLICT_STEP_SIZE_KEY, String.valueOf(5),
+                    "The port step size to use for automatic port resolving in case the port is already used by another program.");
+            PORT_STEP_SIZE = Integer.parseInt(AREProperties.instance.getProperty(ARE_PORT_CONFLICT_STEP_SIZE_KEY));
+        } catch (NumberFormatException e) {
+            AstericsErrorHandling.instance.getLogger().logp(Level.WARNING, this.getClass().getName(), "ServerRepository()",
+                    "Configured value for "+ARE_PORT_CONFLICT_STEP_SIZE_KEY+" not numeric: " + e.getMessage(), e);
+        }        
 
         for(int i=0;i<NR_TRIES_PORT && !success;i++) {        
             int portRest=ServerRepository.getInstance().getPortREST()+i*PORT_STEP_SIZE;

--- a/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/serverUtils/ServerRepository.java
+++ b/ARE/services/WebService/src/main/java/eu/asterics/mw/webservice/serverUtils/ServerRepository.java
@@ -320,4 +320,33 @@ public class ServerRepository {
         restFunctions.addAll(createListOfRestFunctions(SseResource.class));
         return restFunctions;
     }
+
+    /**
+     * @param portREST the portREST to set
+     */
+    public void setPortREST(int portREST) {
+        this.portREST = portREST;
+    }
+
+    /**
+     * @param portWebsocket the portWebsocket to set
+     */
+    public void setPortWebsocket(int portWebsocket) {
+        this.portWebsocket = portWebsocket;
+    }
+
+    /**
+     * @param sslPortREST the sslPortREST to set
+     */
+    public void setSSLPortREST(int sslPortREST) {
+        this.sslPortREST = sslPortREST;
+    }
+
+    /**
+     * @param sslPortWebsocket the sslPortWebsocket to set
+     */
+    public void setSSLPortWebsocket(int sslPortWebsocket) {
+        this.sslPortWebsocket = sslPortWebsocket;
+    }
+
 }

--- a/bin/ARE/web/webapps/startpage/index.html
+++ b/bin/ARE/web/webapps/startpage/index.html
@@ -56,10 +56,10 @@
 				<h3>Applications</h3>
 				<ul id="menu3" class="menuList mainList">
 					<li>
-							<a target="_blank" href="/WebACS/index.html">Local WebACS</a>
+							<a target="_blank" id="localWebACS" href="#">Local WebACS</a>
 					</li>		
 					<li>
-						<a target="_blank" href="https://webacs.asterics.eu/?areBaseURI=http://127.0.0.1:8081">Online WebACS</a>
+						<a target="_blank" id="onlineWebACS" href="#">Online WebACS</a>
 					</li>
 				</ul>
 
@@ -82,6 +82,11 @@
 	</div>
 	
 <!-- ****************************************************** main script ********************************************************** -->	
+
+	<script>		
+		document.getElementById('localWebACS').setAttribute('href','/WebACS/index.html?autoConnect=true&autoDownloadModel=true&areBaseURI='+window.location.origin);
+		document.getElementById('onlineWebACS').setAttribute('href','https://webacs.asterics.eu/?autoConnect=true&autoDownloadModel=true&areBaseURI='+window.location.origin);
+	</script>
     <noscript>
       <div>
         Your web browser must have JavaScript enabled

--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
 	<property name="runtime" location="bin/ARE"/>
 	<property name="web.docroot" location="${runtime}/web/"/>
 	<property name="WebACS.bin" location="${web.docroot}/WebACS"/>
-	<property name="WebACS.version" value="v1.2.0"/>
+	<property name="WebACS.version" value="v1.2.1"/>
 	<property name="tmp.dir" location="tmp"/>
 
 	<target name="clean" description="Clean the whole project">

--- a/build.xml
+++ b/build.xml
@@ -126,6 +126,7 @@
 	<target name="replaceVersion">
 		<getversionnumber text="${env.VERSION}" property="app_version_number" />
 		<echo>VERSION=${env.VERSION}</echo>
+		<replace file="./bin/ACS/asterics.ini" token="#{APPLICATION_VERSION_NUMBER}#" value="${env.VERSION}"/>
 		<replace file="./Installer/setup.iss" token="#{APPLICATION_VERSION_NUMBER}#" value="${env.VERSION}"/>
 		<replace file="./Installer/asterics-are/package/linux/control" token="#{APPLICATION_VERSION_NUMBER}#" value="${env.VERSION}"/>
 		<replace file="./Installer/asterics-are/APE.properties" token="#{APPLICATION_VERSION_NUMBER}#" value="${env.VERSION}"/>


### PR DESCRIPTION
This PR automatically resolves port conflicts (ACS or REST ports) in case of multiple ARE instances.

If a port is already busy, try to find another one. The new port is calculated as follows:
 ```java
int NR_TRIES_PORT=3;
int PORT_STEP_SIZE=5;

for (int i=0;i<NR_TRIES_PORT;i++) {
  int port=port+i*PORT_STEP_SIZE;

  if(bind(port)==true) {
    break;
  }
}
```
This is done for the old ACS ports (9090, 9091 UDPServer) and REST ports (http=8081,ws=8082,https=8083).
Pressing <kbd>F8</kbd> automatically opens the WebACS of the corresponding ARE and opens the model of it.

To know which ARE has which ports, the title of the ARE shows the initial port numbers, e.g.
![image](https://user-images.githubusercontent.com/4621810/80771178-dc6e0b80-8b52-11ea-85af-ef342a73fe62.png)

